### PR TITLE
Fix for issue #142. Do not capitalize 'bool'.

### DIFF
--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -423,7 +423,7 @@ $allMethodsContent
           '\n  @FactoryConverter(request: FormUrlEncodedConverter.requestFactory)';
     }
 
-    if (returnType.isNotEmpty && returnType != 'num') {
+    if (returnType.isNotEmpty && returnType != 'num' && returnType != 'bool') {
       returnType = returnType.pascalCase;
     }
 


### PR DESCRIPTION
Dart builtin type 'bool' is accidentally being capitalized to 'Bool' during code generation.

This fixes the `Future<Response<Bool>>` problem, but I do not know the codebase well so I do not know if there are any other side-effects; although I doubt it.