### PR TITLE
Fix dart parameters that start with '_' or '-'

### DIFF
--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -386,6 +386,14 @@ $allMethodsContent
 
     parameterName = parameterName.replaceAll(',', '');
 
+    // Some API's use an underscore or a dash as the first character in the
+    // parameter. Underscores are a problem because Dart does not allow named
+    // parameters to start with an underscore. Dashes are a problem because
+    // they get confused as a subtraction operator.
+    if (parameterName.startsWith('_') || parameterName.startsWith('-')) {
+      parameterName = parameterName.replaceRange(0, 1, '\$');
+    }
+
     var name = <String>[];
     exceptionWords.forEach((String element) {
       if (parameterName == element) {


### PR DESCRIPTION
Some API's use an underscore or a dash as the first character in the parameter. Underscores are a problem because Dart does not allow named parameters to start with an underscore. Dashes are a problem because they get confused as a subtraction operator.

Ran into both these problems working with an vendor API. The dashed parameters (ex `-id`, `-category`) were used as exclusion filters, but that probably cannot be assumed for all cases. The easy answer seems to be to replace these characters with something else. `$` was chosen because it is already used throughout the codebase.

This doesn't affect the json conversion because it is still recognized that the json key contains those unacceptable characters. They just get mapped to acceptable dart parameter names.

This has the potential to cause duplicate parameter names if `$parameter` happens to also be used by the API for that same endpoint. I don't really see any way of avoiding this without some method of checking for duplicate parameter names during generation. Hopefully it would be a rare occurrence for an API to use both `-id` and `_id` or `$id` in the same endpoint.

As a note, this code was placed above the code that splits at '-' and remerges the name because the leading dash ends up looking like a split point, and is subsequently removed which just hides the issue.