### PR TITLE
[feature] Ability to generate mutable models

### DIFF
--- a/lib/src/code_generators/swagger_additions_generator.dart
+++ b/lib/src/code_generators/swagger_additions_generator.dart
@@ -176,7 +176,7 @@ class \$JsonSerializableConverter extends chopper.JsonConverter {
       return chopper.Response(response.base, null, error: response.error);
     }
 
-    final jsonRes = super.convertResponse<ResultType, Item>(response);
+    final jsonRes = super.convertResponse(response);
     return jsonRes.copyWith<ResultType>(
         body: \$jsonDecoder.decode<Item>(jsonRes.body) as ResultType);
   }

--- a/lib/src/code_generators/swagger_additions_generator.dart
+++ b/lib/src/code_generators/swagger_additions_generator.dart
@@ -164,7 +164,7 @@ class \$CustomJsonDecoder {
   }
 
   List<T> _decodeList<T>(Iterable values) =>
-      values.where((v) => v != null).map<T>((v) => decode<T>(v) as T).toList();
+      values.where((dynamic v) => v != null).map<T>((dynamic v) => decode<T>(v) as T).toList();
 }
 
 class \$JsonSerializableConverter extends chopper.JsonConverter {
@@ -176,7 +176,7 @@ class \$JsonSerializableConverter extends chopper.JsonConverter {
       return chopper.Response(response.base, null, error: response.error);
     }
 
-    final jsonRes = super.convertResponse(response);
+    final jsonRes = super.convertResponse<ResultType, Item>(response);
     return jsonRes.copyWith<ResultType>(
         body: \$jsonDecoder.decode<Item>(jsonRes.body) as ResultType);
   }

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -431,8 +431,8 @@ abstract class SwaggerModelsGenerator {
     }
     var description='';
     if(propertyEntryMap.containsKey('description')) {
-      description = propertyEntryMap['description']?.toString()?.trim()??'';
-      if(!description.isEmpty) description='/// $description\n';
+      description = propertyEntryMap['description'].toString().trim();
+      if(description.isNotEmpty) description='/// $description\n';
     }
 
     final jsonKeyContent =
@@ -512,8 +512,8 @@ abstract class SwaggerModelsGenerator {
 
     var description='\n';
     if(propertyEntryMap.containsKey('description')) {
-      description = propertyEntryMap['description']?.toString()?.trim()??'\n';
-      if(!description.isEmpty) description='/// $description\n';
+      description = propertyEntryMap['description'].toString().trim();
+      if(description.isNotEmpty) description='/// $description\n';
     }
 
     final jsonKeyContent =
@@ -564,8 +564,8 @@ abstract class SwaggerModelsGenerator {
 
     var description='\n';
     if(propertyEntryMap.containsKey('description')) {
-      description = propertyEntryMap['description']?.toString()?.trim()??'\n';
-      if(!description.isEmpty) description='/// $description\n';
+      description = propertyEntryMap['description'].toString().trim();
+      if(description.isNotEmpty) description='/// $description\n';
     }
 
     final jsonKeyContent =
@@ -672,8 +672,8 @@ abstract class SwaggerModelsGenerator {
 
     var description='\n';
     if(propertyEntryMap.containsKey('description')) {
-      description = propertyEntryMap['description']?.toString()?.trim()??'\n';
-      if(!description.isEmpty) description='/// $description\n';
+      description = propertyEntryMap['description'].toString().trim();
+      if(description.isNotEmpty) description='/// $description\n';
     }
 
     String jsonKeyContent;
@@ -749,8 +749,8 @@ abstract class SwaggerModelsGenerator {
     }
     var description='\n';
     if(val.containsKey('description')) {
-      description = val['description']?.toString()?.trim()??'\n';
-      if(!description.isEmpty) description='/// $description\n';
+      description = val['description'].toString().trim();
+      if(description.isNotEmpty) description='/// $description\n';
     }
 
     return '$description\t$jsonKeyContent\t  $typeName $propertyName;';

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -429,10 +429,15 @@ abstract class SwaggerModelsGenerator {
     if (typeName != kDynamic) {
       typeName += '?';
     }
+    var description='';
+    if(propertyEntryMap.containsKey('description')) {
+      description = propertyEntryMap['description']?.toString()?.trim()??'';
+      if(!description.isEmpty) description='/// $description\n';
+    }
 
     final jsonKeyContent =
         "@JsonKey(name: '$propertyName'$includeIfNullString$dateToJsonValue$unknownEnumValue)\n";
-    return '\t$jsonKeyContent\tfinal $typeName ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
+    return '$description\t$jsonKeyContent\t $typeName ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
   }
 
   String generateUnknownEnumValue(List<String> allEnumNames,
@@ -505,10 +510,17 @@ abstract class SwaggerModelsGenerator {
 
     final dateToJsonValue = generateToJsonForDate(propertyEntryMap);
 
+    var description='\n';
+    if(propertyEntryMap.containsKey('description')) {
+      description = propertyEntryMap['description']?.toString()?.trim()??'\n';
+      if(!description.isEmpty) description='/// $description\n';
+    }
+
     final jsonKeyContent =
         "@JsonKey(name: '$propertyKey'$includeIfNullString$unknownEnumValue$dateToJsonValue)\n";
 
-    return '\t$jsonKeyContent\tfinal $typeName? ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
+
+    return '$description\t$jsonKeyContent\t generatePropertyContentBySchema $typeName ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
   }
 
   String generatePropertyContentByRef(
@@ -550,10 +562,16 @@ abstract class SwaggerModelsGenerator {
 
     final includeIfNullString = generateIncludeIfNullString(options);
 
+    var description='\n';
+    if(propertyEntryMap.containsKey('description')) {
+      description = propertyEntryMap['description']?.toString()?.trim()??'\n';
+      if(!description.isEmpty) description='/// $description\n';
+    }
+
     final jsonKeyContent =
         "@JsonKey(name: '$propertyKey'$includeIfNullString$unknownEnumValue)\n";
 
-    return '\t$jsonKeyContent\tfinal $typeName? $propertyName;';
+    return '$description\t$jsonKeyContent\t $typeName? $propertyName;';
   }
 
   String generateEnumPropertyContent(
@@ -575,8 +593,8 @@ abstract class SwaggerModelsGenerator {
     final includeIfNullString = generateIncludeIfNullString(options);
 
     return '''
-  @JsonKey($unknownEnumValue$includeIfNullString)
-  final ${className.capitalize + key.capitalize}? ${SwaggerModelsGenerator.generateFieldName(key)};''';
+  @JsonKey($unknownEnumValue$includeIfNullString)\t
+  ${className.capitalize + key.capitalize} ${SwaggerModelsGenerator.generateFieldName(key)};''';
   }
 
   String generateListPropertyContent(
@@ -652,6 +670,12 @@ abstract class SwaggerModelsGenerator {
 
     final includeIfNullString = generateIncludeIfNullString(options);
 
+    var description='\n';
+    if(propertyEntryMap.containsKey('description')) {
+      description = propertyEntryMap['description']?.toString()?.trim()??'\n';
+      if(!description.isEmpty) description='/// $description\n';
+    }
+
     String jsonKeyContent;
     if (unknownEnumValue.isEmpty) {
       jsonKeyContent =
@@ -661,7 +685,7 @@ abstract class SwaggerModelsGenerator {
           "@JsonKey(name: '$propertyKey'$includeIfNullString$unknownEnumValue)\n";
     }
 
-    return '$jsonKeyContent  final List<$typeName>? ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
+    return '$description$jsonKeyContent\t  List<$typeName>? ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
   }
 
   String generateGeneralPropertyContent(
@@ -723,8 +747,13 @@ abstract class SwaggerModelsGenerator {
     if (typeName != kDynamic) {
       typeName += '?';
     }
+    var description='\n';
+    if(val.containsKey('description')) {
+      description = val['description']?.toString()?.trim()??'\n';
+      if(!description.isEmpty) description='/// $description\n';
+    }
 
-    return '\t$jsonKeyContent  final $typeName $propertyName;';
+    return '$description\t$jsonKeyContent\t  $typeName $propertyName;';
   }
 
   String generatePropertyContentByType(
@@ -949,7 +978,7 @@ List<enums.$neededName> ${neededName.camelCase}ListFromJson(
   }
 
   return ${neededName.camelCase}
-      .map((e) => ${neededName.camelCase}FromJson(e.toString()))
+      .map((dynamic e) => ${neededName.camelCase}FromJson(e.toString()))
       .toList();
 }
     ''';
@@ -1050,8 +1079,8 @@ $copyWithMethod
       String generatedProperties, String validatedClassName) {
     final splittedProperties = generatedProperties
         .split(';')
-        .where((element) => element.isNotEmpty)
-        .map((e) => e.substring(e.indexOf('final ') + 6))
+        .where((element) => element.split('\t').length>2)
+        .map((e) => e.split('\t')[2].trim())
         .map((e) => e.split(' ')[1])
         .toList();
 
@@ -1078,8 +1107,8 @@ $copyWithMethod
       String generatedProperties, String validatedClassName) {
     final splittedProperties = generatedProperties
         .split(';')
-        .where((element) => element.isNotEmpty)
-        .map((e) => e.substring(e.indexOf('final ') + 6))
+        .where((element) => element.split('\t').length>2)
+        .map((e) => e.split('\t')[2].trim())
         .map((e) {
       final items = e.split(' ');
       if (!items.first.endsWith('?')) {
@@ -1107,8 +1136,8 @@ $copyWithMethod
       String generatedProperties, String validatedClassName) {
     final propertiesHash = generatedProperties
         .split(';')
-        .where((element) => element.isNotEmpty)
-        .map((e) => e.substring(e.indexOf('final ') + 6))
+        .where((element) => element.split('\t').length>2)
+        .map((e) => e.split('\t')[2].trim())
         .map((e) => e.substring(e.indexOf(' ') + 1))
         .map((e) => 'const DeepCollectionEquality().hash($e)')
         .toList();

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -429,6 +429,7 @@ abstract class SwaggerModelsGenerator {
     if (typeName != kDynamic) {
       typeName += '?';
     }
+    
     var description='';
     if(propertyEntryMap.containsKey('description')) {
       description = propertyEntryMap['description'].toString().trim();
@@ -437,7 +438,7 @@ abstract class SwaggerModelsGenerator {
 
     final jsonKeyContent =
         "@JsonKey(name: '$propertyName'$includeIfNullString$dateToJsonValue$unknownEnumValue)\n";
-    return '$description\t$jsonKeyContent\t $typeName ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
+    return '$description\t$jsonKeyContent\t${_generateFinalIfImmutable(options)}$typeName ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
   }
 
   String generateUnknownEnumValue(List<String> allEnumNames,
@@ -515,12 +516,11 @@ abstract class SwaggerModelsGenerator {
       description = propertyEntryMap['description'].toString().trim();
       if(description.isNotEmpty) description='/// $description\n';
     }
-
+    
     final jsonKeyContent =
         "@JsonKey(name: '$propertyKey'$includeIfNullString$unknownEnumValue$dateToJsonValue)\n";
-
-
-    return '$description\t$jsonKeyContent\t generatePropertyContentBySchema $typeName ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
+   
+    return '$description\t$jsonKeyContent\t${_generateFinalIfImmutable(options)}$typeName? ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
   }
 
   String generatePropertyContentByRef(
@@ -570,8 +570,8 @@ abstract class SwaggerModelsGenerator {
 
     final jsonKeyContent =
         "@JsonKey(name: '$propertyKey'$includeIfNullString$unknownEnumValue)\n";
-
-    return '$description\t$jsonKeyContent\t $typeName? $propertyName;';
+    
+    return '$description\t$jsonKeyContent\t${_generateFinalIfImmutable(options)}$typeName? $propertyName;';
   }
 
   String generateEnumPropertyContent(
@@ -593,8 +593,8 @@ abstract class SwaggerModelsGenerator {
     final includeIfNullString = generateIncludeIfNullString(options);
 
     return '''
-  @JsonKey($unknownEnumValue$includeIfNullString)\t
-  ${className.capitalize + key.capitalize} ${SwaggerModelsGenerator.generateFieldName(key)};''';
+  @JsonKey($unknownEnumValue$includeIfNullString)
+  \t${_generateFinalIfImmutable(options)}${className.capitalize + key.capitalize}? ${SwaggerModelsGenerator.generateFieldName(key)};''';
   }
 
   String generateListPropertyContent(
@@ -685,8 +685,9 @@ abstract class SwaggerModelsGenerator {
           "@JsonKey(name: '$propertyKey'$includeIfNullString$unknownEnumValue)\n";
     }
 
-    return '$description$jsonKeyContent\t  List<$typeName>? ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
+    return '$description$jsonKeyContent\t${_generateFinalIfImmutable(options)}List<$typeName>? ${SwaggerModelsGenerator.generateFieldName(propertyName)};';
   }
+
 
   String generateGeneralPropertyContent(
       String propertyName,
@@ -753,8 +754,10 @@ abstract class SwaggerModelsGenerator {
       if(description.isNotEmpty) description='/// $description\n';
     }
 
-    return '$description\t$jsonKeyContent\t  $typeName $propertyName;';
+    return '$description\t$jsonKeyContent\t${_generateFinalIfImmutable(options)}$typeName $propertyName;';
   }
+
+  String _generateFinalIfImmutable(GeneratorOptions options) => options.modelsImmutable ? 'final ':'';
 
   String generatePropertyContentByType(
       Map<String, dynamic> propertyEntryMap,
@@ -1081,6 +1084,7 @@ $copyWithMethod
         .split(';')
         .where((element) => element.split('\t').length>2)
         .map((e) => e.split('\t')[2].trim())
+        .map((e) => e.replaceFirst(RegExp(r'^final '),''))
         .map((e) => e.split(' ')[1])
         .toList();
 
@@ -1109,6 +1113,7 @@ $copyWithMethod
         .split(';')
         .where((element) => element.split('\t').length>2)
         .map((e) => e.split('\t')[2].trim())
+        .map((e) => e.replaceFirst(RegExp(r'^final '),''))
         .map((e) {
       final items = e.split(' ');
       if (!items.first.endsWith('?')) {
@@ -1138,6 +1143,7 @@ $copyWithMethod
         .split(';')
         .where((element) => element.split('\t').length>2)
         .map((e) => e.split('\t')[2].trim())
+        .map((e) => e.replaceFirst(RegExp(r'^final '),''))
         .map((e) => e.substring(e.indexOf(' ') + 1))
         .map((e) => 'const DeepCollectionEquality().hash($e)')
         .toList();

--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -140,7 +140,8 @@ class SwaggerRequestsGenerator {
         final method = Method((m) => m
           ..optionalParameters.addAll(parameters)
           ..docs.add(_getCommentsForMethod(
-            methodDescription: swaggerRequest.summary,
+            methodSummary: swaggerRequest.summary,
+            methodDescription: swaggerRequest.description,
             parameters: swaggerRequest.parameters,
             options: options,
           ))
@@ -230,6 +231,7 @@ class SwaggerRequestsGenerator {
   }
 
   String _getCommentsForMethod({
+    required String methodSummary,
     required String methodDescription,
     required List<SwaggerRequestParameter> parameters,
     required GeneratorOptions options,
@@ -241,8 +243,16 @@ class SwaggerRequestsGenerator {
               parameter.inParameter,
               options,
             ));
-
-    final formattedDescription = methodDescription.split('\n').join('\n///');
+    List<String> descriptionLines = [];
+    if(!methodSummary.trim().isEmpty) {
+      descriptionLines.addAll(methodSummary.split('\n'));
+      descriptionLines.add("");
+      descriptionLines.add("");
+    }
+    if(!methodDescription.trim().isEmpty){
+      descriptionLines.addAll(methodDescription.split('\n'));
+    }
+      var formattedDescription = descriptionLines.join('\n///');
 
     return ['///$formattedDescription', ...parametersComments]
         .where((String element) => element.isNotEmpty)

--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -16,6 +16,7 @@ import 'package:collection/collection.dart';
 import 'package:swagger_dart_code_generator/src/extensions/parameter_extensions.dart';
 
 import 'constants.dart';
+import 'swagger_models_generator.dart';
 
 class SwaggerRequestsGenerator {
   String generate({
@@ -243,16 +244,16 @@ class SwaggerRequestsGenerator {
               parameter.inParameter,
               options,
             ));
-    List<String> descriptionLines = [];
-    if(!methodSummary.trim().isEmpty) {
+    var descriptionLines = <String>[];
+    if(methodSummary.trim().isNotEmpty) {
       descriptionLines.addAll(methodSummary.split('\n'));
-      descriptionLines.add("");
-      descriptionLines.add("");
+      descriptionLines.add('');
+      descriptionLines.add('');
     }
-    if(!methodDescription.trim().isEmpty){
+    if(methodDescription.trim().isNotEmpty){
       descriptionLines.addAll(methodDescription.split('\n'));
     }
-      var formattedDescription = descriptionLines.join('\n///');
+    var formattedDescription = descriptionLines.join('\n///');
 
     return ['///$formattedDescription', ...parametersComments]
         .where((String element) => element.isNotEmpty)
@@ -583,7 +584,10 @@ class SwaggerRequestsGenerator {
     required String path,
     required String requestType,
   }) {
-    return SwaggerModelsGenerator.generateRequestName(path, requestType);
+    if(options.usePathForRequestNames || swaggerRequest.operationId.isEmpty){
+        return SwaggerModelsGenerator.generateRequestName(path, requestType);
+    }
+    return SwaggerModelsGenerator.generateFieldName(swaggerRequest.operationId);
   }
 
   static SwaggerResponse? getSuccessedResponse({

--- a/lib/src/extensions/parameter_extensions.dart
+++ b/lib/src/extensions/parameter_extensions.dart
@@ -13,6 +13,7 @@ extension ParameterExtension on Parameter {
           ..required = required
           ..type = type ?? this.type
           ..named = named
+          ..defaultTo = defaultTo
           ..annotations.addAll(annotations ?? this.annotations),
       );
 }

--- a/lib/src/models/generator_options.dart
+++ b/lib/src/models/generator_options.dart
@@ -11,6 +11,7 @@ class GeneratorOptions {
     this.ignoreHeaders = false,
     this.useDefaultNullForLists = false,
     this.buildOnlyModels = false,
+    this.usePathForRequestNames = true,
     this.defaultValuesMap = const <DefaultValueMap>[],
     this.defaultHeaderValuesMap = const <DefaultHeaderValueMap>[],
     this.responseOverrideValueMap = const <ResponseOverrideValueMap>[],
@@ -61,6 +62,9 @@ class GeneratorOptions {
 
   @JsonKey(defaultValue: false)
   final bool buildOnlyModels;
+
+  @JsonKey(defaultValue: true)
+  final bool usePathForRequestNames;
 
   @JsonKey(defaultValue: '')
   final String modelPostfix;

--- a/lib/src/models/generator_options.dart
+++ b/lib/src/models/generator_options.dart
@@ -12,6 +12,7 @@ class GeneratorOptions {
     this.useDefaultNullForLists = false,
     this.buildOnlyModels = false,
     this.usePathForRequestNames = true,
+    this.modelsImmutable = true,
     this.defaultValuesMap = const <DefaultValueMap>[],
     this.defaultHeaderValuesMap = const <DefaultHeaderValueMap>[],
     this.responseOverrideValueMap = const <ResponseOverrideValueMap>[],
@@ -65,6 +66,9 @@ class GeneratorOptions {
 
   @JsonKey(defaultValue: true)
   final bool usePathForRequestNames;
+
+  @JsonKey(defaultValue: true)
+  final bool modelsImmutable;
 
   @JsonKey(defaultValue: '')
   final String modelPostfix;

--- a/lib/src/models/generator_options.g2.dart
+++ b/lib/src/models/generator_options.g2.dart
@@ -38,6 +38,7 @@ GeneratorOptions _$GeneratorOptionsFromJson(Map json) {
         json['use_required_attribute_for_headers'] as bool? ?? true,
     useInheritance: json['use_inheritance'] as bool? ?? true,
     usePathForRequestNames: json['use_path_for_request_names'] as bool? ?? true,
+    modelsImmutable: json['models_immutable'] as bool? ?? true,
     includeIfNull: json['include_if_null'] as bool?,
     modelPostfix: json['model_postfix'] as String? ?? '',
     includePaths: (json['include_paths'] as List<dynamic>?)
@@ -60,6 +61,7 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
       'ignore_headers': instance.ignoreHeaders,
       'use_inheritance': instance.useInheritance,
       'use_path_for_request_names': instance.usePathForRequestNames,
+      'models_immutable': instance.modelsImmutable,
       'enums_case_sensitive': instance.enumsCaseSensitive,
       'include_if_null': instance.includeIfNull,
       'input_folder': instance.inputFolder,

--- a/lib/src/models/generator_options.g2.dart
+++ b/lib/src/models/generator_options.g2.dart
@@ -37,6 +37,7 @@ GeneratorOptions _$GeneratorOptionsFromJson(Map json) {
     useRequiredAttributeForHeaders:
         json['use_required_attribute_for_headers'] as bool? ?? true,
     useInheritance: json['use_inheritance'] as bool? ?? true,
+    usePathForRequestNames: json['use_path_for_request_names'] as bool? ?? true,
     includeIfNull: json['include_if_null'] as bool?,
     modelPostfix: json['model_postfix'] as String? ?? '',
     includePaths: (json['include_paths'] as List<dynamic>?)
@@ -58,6 +59,7 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
           instance.useRequiredAttributeForHeaders,
       'ignore_headers': instance.ignoreHeaders,
       'use_inheritance': instance.useInheritance,
+      'use_path_for_request_names': instance.usePathForRequestNames,
       'enums_case_sensitive': instance.enumsCaseSensitive,
       'include_if_null': instance.includeIfNull,
       'input_folder': instance.inputFolder,

--- a/test/generator_tests/models_generator_test.dart
+++ b/test/generator_tests/models_generator_test.dart
@@ -11,12 +11,20 @@ void main() {
   group('generate', () {
     const fileName = 'order_service.dart';
 
-    test('Should parse object name as a field Type', () {
+    test('Should parse object name as a immutable field Type', () {
       final result = generator.generate(model_with_parameters_v3, fileName,
-          GeneratorOptions(inputFolder: '', outputFolder: ''));
+          GeneratorOptions(inputFolder: '', outputFolder: '', modelsImmutable: true));
 
       expect(
-          result, contains('final enums.TokensResponseTokenType? tokenType'));
+          result, contains('\n\tfinal enums.TokensResponseTokenType? tokenType'));
+    });
+
+    test('Should parse object name as a mutable field Type', () {
+      final result = generator.generate(model_with_parameters_v3, fileName,
+          GeneratorOptions(inputFolder: '', outputFolder: '', modelsImmutable: false));
+
+      expect(
+          result, contains('\n\tenums.TokensResponseTokenType? tokenType'));
     });
 
     test('Should generate .toLower() when caseSensitive: false', () {
@@ -461,7 +469,7 @@ void main() {
       expect(result, contains(fieldExpectedResult));
     });
 
-    test('Should return properties from schema', () {
+    test('Should return immutable properties from schema', () {
       final map = <String, dynamic>{
         'Animals': <String, dynamic>{
           'schema': <String, dynamic>{'\$ref': '#/definitions/Pet'}
@@ -470,7 +478,7 @@ void main() {
 
       const className = 'Animals';
       const jsonKeyExpectedResult = "\t@JsonKey(name: 'Animals')\n";
-      const fieldExpectedResult = 'final Pet? animals';
+      const fieldExpectedResult = '\n\tfinal Pet? animals';
       final result = generator.generatePropertiesContent(
           map,
           {},
@@ -479,7 +487,31 @@ void main() {
           false,
           [],
           [],
-          GeneratorOptions(inputFolder: '', outputFolder: ''));
+          GeneratorOptions(inputFolder: '', outputFolder: '', modelsImmutable: true));
+
+      expect(result, contains(jsonKeyExpectedResult));
+      expect(result, contains(fieldExpectedResult));
+    });
+
+    test('Should return mutable properties from schema', () {
+      final map = <String, dynamic>{
+        'Animals': <String, dynamic>{
+          'schema': <String, dynamic>{'\$ref': '#/definitions/Pet'}
+        }
+      };
+
+      const className = 'Animals';
+      const jsonKeyExpectedResult = "\t@JsonKey(name: 'Animals')\n";
+      const fieldExpectedResult = '\n\tPet? animals';
+      final result = generator.generatePropertiesContent(
+          map,
+          {},
+          className,
+          <DefaultValueMap>[],
+          false,
+          [],
+          [],
+          GeneratorOptions(inputFolder: '', outputFolder: '', modelsImmutable: false));
 
       expect(result, contains(jsonKeyExpectedResult));
       expect(result, contains(fieldExpectedResult));


### PR DESCRIPTION
I needed the ability to generate mutable, non-final models, so I went ahead and added it. 
Offering this PR if you'd like the option as well.

Usage:
new option `models_immutable`, default is `false`. When `true`, the `final` keyword is omitted from model properties.

I also restored (#204 ) the functionality of the `use_path_for_request_names` option, because it wasn't working and I needed it. Default is now `true`. When `false`, the swagger `operationId` is used as the method name (but converted to lowerCamelCase). The path-generated method names looked particularly ugly for me, whereas in my C# Azure Function I have declared the operationId as the same as the Azure Function (& C# method) name, so this lines up perfectly for me. (I'm using this project in the backend: https://github.com/Azure/azure-functions-openapi-extension )

I also added swagger method `description` fields as comments, in addition to the existing `summary`. The `azure-functions-openapi-extension` only seems to generate `description`s.

Finally, I added unit tests for the codegen output with `models_immutable` both true and false.