### PR TITLE
Allow passing baseUrl to constructor

### DIFF
--- a/lib/src/code_generators/swagger_additions_generator.dart
+++ b/lib/src/code_generators/swagger_additions_generator.dart
@@ -181,7 +181,7 @@ final \$jsonDecoder = \$CustomJsonDecoder(generatedMapping);
     GeneratorOptions options,
   ) {
     final baseUrlString = options.withBaseUrl
-        ? "baseUrl:  'https://$host$basePath'"
+        ? "baseUrl:  baseUrl ?? 'http://$host$basePath'"
         : '/*baseUrl: YOUR_BASE_URL*/';
 
     final converterString = options.withConverter

--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -78,10 +78,18 @@ class SwaggerRequestsGenerator {
         ..optionalParameters.add(
           Parameter(
             (p) => p
-              ..named = false
+              ..named = true
               ..type = Reference('ChopperClient?')
               ..name = 'client',
-          ),
+          )
+        )
+        ..optionalParameters.add(
+          Parameter(
+                (p) => p
+              ..named = true
+              ..type = Reference('String?')
+              ..name = 'baseUrl',
+          )
         )
         ..body = Code(body),
     );


### PR DESCRIPTION
I thought it was convenient to be able to pass the `baseUrl` to the generated `create` method.

This is change breaks backwards compatibility, because the arguments were changed to **named**. You might want to leave them as positional parameters, but the usage looks a little awkward with passing nulls.