### PR TITLE
Various fixes

### DIFF
--- a/lib/src/code_generators/swagger_enums_generator.dart
+++ b/lib/src/code_generators/swagger_enums_generator.dart
@@ -277,15 +277,15 @@ $enumMap
       final value = enumValues[i];
       var validatedValue = value;
 
-      while (fields.contains(validatedValue)) {
-        validatedValue += '\$';
-      }
-
       if (enumValuesNames.length == enumValues.length) {
         validatedValue = enumValuesNames[i];
       }
 
       validatedValue = getValidatedEnumFieldName(validatedValue);
+
+      while (fields.contains(validatedValue)) {
+        validatedValue += '\$';
+      }
 
       fields.add(validatedValue);
       neededStrings.add(

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -1182,7 +1182,7 @@ $copyWithMethod
         .map((e) => e.substring(e.indexOf('final ') + 6))
         .map((e) {
       final items = e.split(' ');
-      if (!items.first.endsWith('?')) {
+      if (!items[0].endsWith('?') && items[0] != 'dynamic') {
         items[0] += '?';
       }
 

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -1194,7 +1194,7 @@ $copyWithMethod
         .map((e) => e.substring(e.indexOf('final ') + 6))
         .map((e) {
       final items = e.split(' ');
-      if (!items[0].endsWith('?') && items[0] != 'dynamic') {
+      if (!items[0].endsWith('?') && items[0] != kDynamic) {
         items[0] += '?';
       }
 

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -471,6 +471,10 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
     } else {
       typeName =
           getValidatedClassName(allOf.first['\$ref'].toString().getRef());
+
+      if (allEnumNames.contains('enums.$typeName')) {
+        typeName = 'enums.$typeName';
+      }
     }
 
     final includeIfNullString = generateIncludeIfNullString();

--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -165,6 +165,7 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
           ..docs.add(_getCommentsForMethod(
             methodDescription: swaggerRequest.summary,
             parameters: swaggerRequest.parameters,
+            components: swaggerRoot.components?.parameters,
           ))
           ..name = methodName
           ..annotations
@@ -307,13 +308,21 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
   String _getCommentsForMethod({
     required String methodDescription,
     required List<SwaggerRequestParameter> parameters,
+    required Map<String, SwaggerRequestParameter>? components,
   }) {
-    final parametersComments = parameters
-        .map((SwaggerRequestParameter parameter) => _createSummaryParameters(
-              parameter.name,
-              parameter.description,
-              parameter.inParameter,
-            ));
+    final parametersComments =
+        parameters.map((SwaggerRequestParameter parameter) {
+      if (components != null) {
+        var key = parameter.ref.split('/').last;
+        parameter = components[key] ?? parameter;
+      }
+
+      return _createSummaryParameters(
+        parameter.name,
+        parameter.description,
+        parameter.inParameter,
+      );
+    });
 
     final formattedDescription = methodDescription.split('\n').join('\n///');
 

--- a/lib/src/extensions/string_extension.dart
+++ b/lib/src/extensions/string_extension.dart
@@ -1,4 +1,5 @@
 import 'package:recase/recase.dart';
+import 'package:swagger_dart_code_generator/src/code_generators/constants.dart';
 import 'package:swagger_dart_code_generator/src/code_generators/swagger_models_generator.dart';
 
 extension CapitalizeExtension on String {
@@ -45,7 +46,7 @@ extension TypeExtension on String {
 
   String asParameterType() {
     if (isEmpty) {
-      return 'dynamic';
+      return kDynamic;
     }
 
     final result =


### PR DESCRIPTION
I've been trying to generate [Spotify's OpenAPI schema](https://developer.spotify.com/_data/documentation/web-api/reference/open-api-schema.yml) and initially ran into a few problems. This pull request addresses these issues and includes proposed fixes.

#

### 1st Issue: #384 - Missing parameter annotations when parsing "$ref" fields
As described in the linked issue, it wasn't possible to generate a `@param` docstring for request parameters that utilize OpenAPI's [`$ref` keyword](https://swagger.io/docs/specification/using-ref/). To fix this, I'm passing the "components.parameters" section on to `_generateCommentsForMethod()`. If a parameter holds a reference to any component, the component's properties are used instead to generate comments.

#

### 2nd Issue: Avoid `dynamic?` type in `copyWith()`
This one's pretty straightforward. After running the generator, the Dart analyzer threw the same warning multiple times: `The '?' is unnecessary because 'dynamic' is nullable without it.` The fix for this issue is as simple as an additional condition to check if the parameter is dynamic or not.

#

### 3rd Issue: Use "enums" library prefix when generating "allOf"
Another bug I encountered with generating the Spotify API scheme was a single missing `enums.`-prefix. 
```dart
@JsonKey(name: 'status')
final int? status;
@JsonKey(name: 'message')
final String? message;
@JsonKey(name: 'reason')
final PlayerErrorReasons? reason; // <------ Undefined class 'PlayerErrorReasons'
```
This was due to the following schema:
```yaml
components:
  schemas:
    PlayerErrorObject:
      type: object
      properties:
        status:
          type: integer
        message:
          type: string
        reason:
          allOf:
            - $ref: '#/components/schemas/PlayerErrorReasons'

    PlayerErrorReasons:
      type: string
      enum:
        - NO_PREV_TRACK
        - NO_NEXT_TRACK
        - NO_SPECIFIC_TRACK
        - ALREADY_PAUSED
        - [...]
```

If a class property consists of an [`allOf` keyword](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#allof) and the allOf contains only one object, the generator will try to recognize its type. This works fine for all types except for enums, as they must include the "enums" prefix. I fixed this by checking whether the class name is contained in `allEnumNames`. If that's the case, the prefix gets prepended.

#

### 4th Issue: Duplicate enum keys
```dart
enum SectionObjectMode {
  @JsonValue('swaggerGeneratedUnknown')
  swaggerGeneratedUnknown,
  @JsonValue('-1')
  value_1,
  @JsonValue('0')
  value_0,
  @JsonValue('1')
  value_1$
}

const $SectionObjectModeMap = {
  SectionObjectMode.value_1: '-1', // <-------
  SectionObjectMode.value_0: '0',
  SectionObjectMode.value_1: '1'   // <------ Same enum key used twice
};
```

This bug was caused by differences between two methods in `swagger_enums_generator.dart` that should perform similar actions in the same order. However, the code got switched around in one of these methods: [lines 243-254](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/blob/d3924c66d8f6edeec466cfaed8e89e03df78c4b6/lib/src/code_generators/swagger_enums_generator.dart#L243-L254) and [lines 277-288](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/blob/d3924c66d8f6edeec466cfaed8e89e03df78c4b6/lib/src/code_generators/swagger_enums_generator.dart#L277-L288)

I rearranged the code so that both methods now follow the correct order (validate first, append `$` symbols second).

#

Hopefully this is not too vague of a pull request. All changes to the code are non-breaking and should only grant better support for code generation.

Cheers