### PR TITLE
Respect "nullable: true"

### DIFF
--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -456,6 +456,21 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     return '';
   }
 
+  String nullable(
+    String typeName,
+    String className,
+    Iterable<String> requiredProperties,
+    String propertyKey,
+    Map<String, dynamic> propertyEntryMap,
+  ) {
+    if (options.nullableModels.contains(className) ||
+        !requiredProperties.contains(propertyKey) ||
+        propertyEntryMap['nullable'] == true) {
+      return typeName.makeNullable();
+    }
+    return typeName;
+  }
+
   String generatePropertyContentBySchema(
     Map<String, dynamic> propertyEntryMap,
     String propertyName,
@@ -502,10 +517,8 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     final jsonKeyContent =
         "@JsonKey(name: '$propertyKey'$includeIfNullString${unknownEnumValue.jsonKey}$dateToJsonValue)\n";
 
-    if (options.nullableModels.contains(className) ||
-        !requiredProperties.contains(propertyKey)) {
-      typeName = typeName.makeNullable();
-    }
+    typeName = nullable(
+        typeName, className, requiredProperties, propertyKey, propertyEntryMap);
 
     return '\t$jsonKeyContent\tfinal $typeName ${generateFieldName(propertyName)};${unknownEnumValue.fromJson}';
   }
@@ -549,10 +562,8 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     final jsonKeyContent =
         "@JsonKey(name: '$propertyKey'$includeIfNullString${unknownEnumValue.jsonKey})\n";
 
-    if (options.nullableModels.contains(className) ||
-        !requiredProperties.contains(propertyKey)) {
-      typeName = typeName.makeNullable();
-    }
+    typeName = nullable(
+        typeName, className, requiredProperties, propertyKey, propertyEntryMap);
 
     return '\t$jsonKeyContent\tfinal $typeName $propertyName;${unknownEnumValue.fromJson}';
   }
@@ -606,10 +617,8 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     final jsonKeyContent =
         "@JsonKey(name: '$propertyKey'$includeIfNullString${unknownEnumValue.jsonKey})\n";
 
-    if (options.nullableModels.contains(className) ||
-        !requiredProperties.contains(propertyKey)) {
-      typeName = typeName.makeNullable();
-    }
+    typeName = nullable(
+        typeName, className, requiredProperties, propertyKey, propertyEntryMap);
 
     return '\t$jsonKeyContent\tfinal $typeName $propertyName;${unknownEnumValue.fromJson}';
   }
@@ -639,10 +648,8 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     final includeIfNullString = generateIncludeIfNullString();
 
     var enumPropertyName = className.capitalize + key.capitalize;
-    if (options.nullableModels.contains(className) ||
-        !requiredProperties.contains(propertyKey)) {
-      enumPropertyName = enumPropertyName.makeNullable();
-    }
+    enumPropertyName = nullable(enumPropertyName, className, requiredProperties,
+        propertyKey, propertyEntryMap);
 
     return '''
   @JsonKey(${unknownEnumValue.jsonKey.substring(2)}$includeIfNullString)
@@ -769,10 +776,8 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
 
     var listPropertyName = 'List<$typeName>';
 
-    if (options.nullableModels.contains(className) ||
-        !requiredParameters.contains(propertyKey)) {
-      listPropertyName = listPropertyName.makeNullable();
-    }
+    listPropertyName = nullable(listPropertyName, className, requiredParameters,
+        propertyKey, propertyEntryMap);
 
     return '$jsonKeyContent  final $listPropertyName ${generateFieldName(propertyName)};${unknownEnumValue.fromJson}';
   }
@@ -842,10 +847,8 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       jsonKeyContent += ')\n';
     }
 
-    if (options.nullableModels.contains(className) ||
-        !requiredProperties.contains(propertyKey)) {
-      typeName += '?';
-    }
+    typeName =
+        nullable(typeName, className, requiredProperties, propertyKey, val);
 
     return '\t$jsonKeyContent  final $typeName $propertyName;${unknownEnumValue.fromJson}';
   }

--- a/lib/src/swagger_models/responses/swagger_schema.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.dart
@@ -13,6 +13,7 @@ class SwaggerSchema {
     required this.ref,
     required this.defaultValue,
     required this.format,
+    required this.isNullable,
     required this.schema,
     required this.oneOf,
     required this.anyOf,
@@ -48,6 +49,9 @@ class SwaggerSchema {
 
   @JsonKey(name: 'properties', defaultValue: {})
   Map<String, SwaggerSchema> properties;
+
+  @JsonKey(name: 'nullable', defaultValue: false)
+  bool isNullable;
 
   @JsonKey(name: 'schema')
   SwaggerSchema? schema;

--- a/lib/src/swagger_models/responses/swagger_schema.g2.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.g2.dart
@@ -22,6 +22,7 @@ SwaggerSchema _$SwaggerSchemaFromJson(Map<String, dynamic> json) =>
       ref: json[r'$ref'] as String? ?? '',
       defaultValue: json['default'],
       format: json['format'] as String? ?? '',
+      isNullable: json['nullable'] as bool? ?? false,
       schema: json['schema'] == null
           ? null
           : SwaggerSchema.fromJson(json['schema'] as Map<String, dynamic>),
@@ -47,6 +48,7 @@ Map<String, dynamic> _$SwaggerSchemaToJson(SwaggerSchema instance) =>
       'enum': instance.enumValuesObj,
       'items': instance.items,
       'properties': instance.properties,
+      'nullable': instance.isNullable,
       'schema': instance.schema,
       'oneOf': instance.oneOf,
       'anyOf': instance.anyOf,


### PR DESCRIPTION
Apart from a small refactor to reduce duplicate code, this pull request introduces the change of making variables nullable if a schema contains [`nullable: true`](https://swagger.io/docs/specification/data-models/data-types/#null). For example:
```yaml
UserObject:
  type: object
  properties:
    display_name:
      type: string
      nullable: true   # <----- "nullable" property
      description: |
        The name displayed on the user's profile. `null` if not available.
```
This configuration will now generate a `String?` type variable instead of a `String` type.
```dart
@JsonKey(name: 'display_name')
final String? displayName;
```