### PR TITLE
Impove multipart support

### DIFF
--- a/lib/src/code_generators/constants.dart
+++ b/lib/src/code_generators/constants.dart
@@ -83,6 +83,7 @@ const kArray = 'array';
 const kEnum = 'enum';
 const kBody = 'body';
 const kPartFile = 'partFile';
+const kPart = 'part';
 
 const kDynamic = 'dynamic';
 

--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -636,21 +636,41 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
 
     if (requestBody != null) {
       if (requestBody.content?.isMultipart == true) {
-        result.add(
-          Parameter(
-            (p) => p
-              ..name = kPartFile
-              ..named = true
-              ..required = true
-              ..type = Reference(
-                'List<int>',
-              )
-              ..named = true
-              ..annotations.add(
-                refer(kPartFile.pascalCase).call([]),
+        final schema = requestBody.content?.schema;
+        schema?.properties.forEach((key, value) {
+          if (value.type == 'string' && value.format == 'binary') {
+            result.add(
+              Parameter(
+                (p) => p
+                  ..name = key
+                  ..named = true
+                  ..required = schema.required.contains(key)
+                  ..type = Reference(
+                    'List<int>',
+                  )
+                  ..named = true
+                  ..annotations.add(
+                    refer(kPartFile.pascalCase).call([]),
+                  ),
               ),
-          ),
-        );
+            );
+          } else {
+            result.add(
+              Parameter(
+                (p) => p
+                  ..name = key
+                  ..named = true
+                  ..required = schema.required.contains(key)
+                  ..type = Reference(
+                      _mapParameterName(value.type, value.format, modelPostfix))
+                  ..named = true
+                  ..annotations.add(
+                    refer(kPart.pascalCase).call([]),
+                  ),
+              ),
+            );
+          }
+        });
 
         return result.distinctParameters();
       }

--- a/lib/src/swagger_models/requests/swagger_request.dart
+++ b/lib/src/swagger_models/requests/swagger_request.dart
@@ -80,7 +80,9 @@ RequestContent? _contentFromJson(Map<String, dynamic>? map) {
   }
 
   if (map.containsKey('multipart/form-data')) {
-    return RequestContent(isMultipart: true);
+    final multipart = map['multipart/form-data']['schema'] as Map<String, dynamic>;
+    return RequestContent(
+        isMultipart: true, schema: SwaggerSchema.fromJson(multipart));
   }
 
   final content = map.values.first as Map<String, dynamic>;

--- a/test/generator_tests/requests_generator_test.dart
+++ b/test/generator_tests/requests_generator_test.dart
@@ -47,6 +47,8 @@ void main() {
       expect(result2, contains('Future<chopper.Response<CarModel>>'));
       expect(result, contains('Future<chopper.Response<CarModel>> carsGet'));
       expect(result, contains('Future<chopper.Response<CarModel>> carsPost'));
+      expect(result, contains('Future<chopper.Response<CarModel>> carsMultipartPost'));
+      expect(result, contains('{@Part() required String filename, @PartFile() required List<int> file}'));
     });
   });
 }

--- a/test/generator_tests/test_data.dart
+++ b/test/generator_tests/test_data.dart
@@ -185,6 +185,44 @@ const carsService = '''
                 }
             }
         },
+        "/cars/multipart": {
+            "post": {
+                "summary": "Sends multipart with multiple parts",
+                "requestBody": {
+                    "description": "Car model as file",
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "filename": {
+                                        "type": "string"
+                                    },
+                                    "file": {
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                },
+                                "required": ["filename", "file"]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Car successfully uploaded",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CarModel"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/cars/optionalBody": {
             "post": {
                 "summary": "Its needed to test optionalBody",


### PR DESCRIPTION
Current multipart support had only one part with hardcoded name, instead the schema should be used to determine the parts.