### PR TITLE
Extend parent class if present

### DIFF
--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -1275,7 +1275,7 @@ List<enums.$neededName> ${neededName.camelCase}ListFromJson(
     final equalsOverride =
         generateEqualsOverride(generatedProperties, validatedClassName);
 
-    final parentContent = parent != null ? 'extends $parent ' : '';
+    final parentContent = parent != null ? 'implements $parent ' : '';
 
     final generatedClass = '''
 @JsonSerializable(explicitToJson: true)

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -1238,7 +1238,7 @@ List<enums.$neededName> ${neededName.camelCase}ListFromJson(
     Map<String, SwaggerSchema> allClasses,
   ) {
     final properties = getModelProperties(schema, schemas);
-    final requiredProperties = schema.required;
+    final requiredProperties = _getRequired(schema, schemas);
     final parent = _getParent(schema, schemas);
 
     final generatedConstructorProperties = generateConstructorPropertiesContent(
@@ -1298,6 +1298,18 @@ $copyWithMethod
 ''';
 
     return generatedClass;
+  }
+
+  List<String> _getRequired(
+      SwaggerSchema schema, Map<String, SwaggerSchema> schemas) {
+    if (schema.hasRef) {
+      final parentName = schema.ref.split('/').last.pascalCase;
+      final parentSchema = schemas[parentName];
+      return schema.required +
+          (parentSchema != null ? _getRequired(parentSchema, schemas) : []);
+    } else {
+      return schema.required;
+    }
   }
 
   List<SwaggerSchema> _getInterfaces(SwaggerSchema schema) {

--- a/lib/src/swagger_models/responses/swagger_schema.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.dart
@@ -23,6 +23,7 @@ class SwaggerSchema {
     this.enumNames,
     this.isNullable = false,
     this.hasAdditionalProperties = false,
+    this.discriminator = const {}
   });
 
   @JsonKey(name: 'type', defaultValue: '')
@@ -65,6 +66,9 @@ class SwaggerSchema {
 
   @JsonKey(name: 'properties', defaultValue: {})
   Map<String, SwaggerSchema> properties;
+
+  @JsonKey(name: 'discriminator', defaultValue: {})
+  Map<String, Object> discriminator;
 
   @JsonKey(name: 'nullable', defaultValue: false)
   bool isNullable;

--- a/lib/src/swagger_models/responses/swagger_schema.g2.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.g2.dart
@@ -13,8 +13,8 @@ SwaggerSchema _$SwaggerSchemaFromJson(Map<String, dynamic> json) =>
       enumValuesObj: json['enum'] as List<dynamic>? ?? [],
       properties: (json['properties'] as Map<String, dynamic>?)?.map(
             (k, e) =>
-                MapEntry(k, SwaggerSchema.fromJson(e as Map<String, dynamic>)),
-          ) ??
+            MapEntry(k, SwaggerSchema.fromJson(e as Map<String, dynamic>)),
+      ) ??
           {},
       items: json['items'] == null
           ? null
@@ -26,16 +26,16 @@ SwaggerSchema _$SwaggerSchemaFromJson(Map<String, dynamic> json) =>
           ? null
           : SwaggerSchema.fromJson(json['schema'] as Map<String, dynamic>),
       oneOf: (json['oneOf'] as List<dynamic>?)
-              ?.map((e) => SwaggerSchema.fromJson(e as Map<String, dynamic>))
-              .toList() ??
+          ?.map((e) => SwaggerSchema.fromJson(e as Map<String, dynamic>))
+          .toList() ??
           [],
       anyOf: (json['anyOf'] as List<dynamic>?)
-              ?.map((e) => SwaggerSchema.fromJson(e as Map<String, dynamic>))
-              .toList() ??
+          ?.map((e) => SwaggerSchema.fromJson(e as Map<String, dynamic>))
+          .toList() ??
           [],
       allOf: (json['allOf'] as List<dynamic>?)
-              ?.map((e) => SwaggerSchema.fromJson(e as Map<String, dynamic>))
-              .toList() ??
+          ?.map((e) => SwaggerSchema.fromJson(e as Map<String, dynamic>))
+          .toList() ??
           [],
       required: json['required'] == null
           ? const []
@@ -48,6 +48,10 @@ SwaggerSchema _$SwaggerSchemaFromJson(Map<String, dynamic> json) =>
       hasAdditionalProperties: json['additionalProperties'] == null
           ? false
           : _additionalsFromJson(json['additionalProperties']),
+      discriminator: (json['discriminator'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, e as Object),
+      ) ??
+          {},
     );
 
 Map<String, dynamic> _$SwaggerSchemaToJson(SwaggerSchema instance) =>
@@ -62,6 +66,7 @@ Map<String, dynamic> _$SwaggerSchemaToJson(SwaggerSchema instance) =>
       'required': instance.required,
       'items': instance.items,
       'properties': instance.properties,
+      'discriminator': instance.discriminator,
       'nullable': instance.isNullable,
       'schema': instance.schema,
       'oneOf': instance.oneOf,


### PR DESCRIPTION
When discriminator is present on the parent (which means that the schema uses allOf, anyOf, oneOf) the current class should extend the parent schema class.
Example:
```
    Model:
      properties:
        modelProp:
          type: string
      required:
        - modelProp
      discriminator:
        propertyName: modelProp
    SubModel:
      allOf:
        - $ref: '#/components/schemas/Model'
        - type: object
          properties:
            other:
              type: string
      required:
        - other
```

Should result in:
```
class Model{...}

class SubModel extends Model{...}
```