### PR TITLE
Deserialise using polymorphism

### DIFF
--- a/lib/src/swagger_models/responses/swagger_schema.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.dart
@@ -23,7 +23,7 @@ class SwaggerSchema {
     this.enumNames,
     this.isNullable = false,
     this.hasAdditionalProperties = false,
-    this.discriminator = const {}
+    this.discriminator,
   });
 
   @JsonKey(name: 'type', defaultValue: '')
@@ -67,8 +67,8 @@ class SwaggerSchema {
   @JsonKey(name: 'properties', defaultValue: {})
   Map<String, SwaggerSchema> properties;
 
-  @JsonKey(name: 'discriminator', defaultValue: {})
-  Map<String, Object> discriminator;
+  @JsonKey(name: 'discriminator', defaultValue: null)
+  Discriminator? discriminator;
 
   @JsonKey(name: 'nullable', defaultValue: false)
   bool isNullable;
@@ -103,6 +103,21 @@ class SwaggerSchema {
         ..._$SwaggerSchemaToJson(this),
         if (enumNames != null) kEnumNames: enumNames,
       };
+}
+
+@JsonSerializable()
+class Discriminator {
+  Discriminator({this.propertyName = '', this.mapping = const {}});
+
+  @JsonKey(name: 'propertyName', defaultValue: '')
+  String propertyName;
+  @JsonKey(name: 'mapping', defaultValue: {})
+  Map<String, String> mapping;
+
+  factory Discriminator.fromJson(Map<String, dynamic> json) =>
+      _$DiscriminatorFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DiscriminatorToJson(this);
 }
 
 bool _additionalsFromJson(dynamic value) => value != false;

--- a/lib/src/swagger_models/responses/swagger_schema.g2.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.g2.dart
@@ -48,10 +48,10 @@ SwaggerSchema _$SwaggerSchemaFromJson(Map<String, dynamic> json) =>
       hasAdditionalProperties: json['additionalProperties'] == null
           ? false
           : _additionalsFromJson(json['additionalProperties']),
-      discriminator: (json['discriminator'] as Map<String, dynamic>?)?.map(
-            (k, e) => MapEntry(k, e as Object),
-      ) ??
-          {},
+      discriminator: json['discriminator'] == null
+          ? null
+          : Discriminator.fromJson(
+          json['discriminator'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$SwaggerSchemaToJson(SwaggerSchema instance) =>
@@ -74,4 +74,19 @@ Map<String, dynamic> _$SwaggerSchemaToJson(SwaggerSchema instance) =>
       'allOf': instance.allOf,
       'additionalProperties': instance.hasAdditionalProperties,
       'enumNames': instance.enumNames,
+    };
+
+Discriminator _$DiscriminatorFromJson(Map<String, dynamic> json) =>
+    Discriminator(
+      propertyName: json['propertyName'] as String? ?? '',
+      mapping: (json['mapping'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, e as String),
+      ) ??
+          {},
+    );
+
+Map<String, dynamic> _$DiscriminatorToJson(Discriminator instance) =>
+    <String, dynamic>{
+      'propertyName': instance.propertyName,
+      'mapping': instance.mapping,
     };


### PR DESCRIPTION
Currently there is support for generating the model based on the discriminator but it's not taken into account when deserialising.
So if the spec says:
```
 Model:
  properties:
    modelProp:
      type: string
  required:
    - modelProp
  discriminator:
    propertyName: modelProp
    mapping:
      'SUB': '#/components/schemas/SubModel'
SubModel:
  allOf:
    - $ref: '#/components/schemas/Model'
    - type: object
      properties:
        other:
          type: string
  required:
    - other
```
We should generate:
```
  factory Model.fromJson(Map<String, dynamic> json) {
    switch (json['modelProp']) {
      case 'SUB':
        return _$SubModelFromJson(json);
      default:
        return _$ModelFromJson(json);
    }
  }
```

So that we get the subtype instead of the parent type when needed.