### PR TITLE
Collision between @Body attribute and schema called 'Body'

### DIFF
--- a/lib/src/code_generators/constants.dart
+++ b/lib/src/code_generators/constants.dart
@@ -8,6 +8,7 @@ const List<String> kKeyClasses = [
   'Request',
   'Type',
   'Query',
+  'Body',
 ];
 
 const kBasicTypes = [


### PR DESCRIPTION
I have a swagger.json which contains a schema called `Body`:

```json
            "Body": {
                "type": "object",
                "properties": {
                   ...
                },
                "additionalProperties": false
            },
```

Currently this generates a class called `Body`, this collides with the chopper `@Body ` annotation.

I've resolved the issue by adding `Body` to the `kKeyClasses` constant.
Now the class generated for the class is `Body$` and doesn't collide with the `@Body` annotation anymore.