### PR TITLE
Avoid name collision of copyWith extension methods

### DIFF
--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -1414,7 +1414,7 @@ $copyWithWrapped
         .map((e) => '$e: ($e != null ? $e.value : this.$e)')
         .join(',\n');
 
-    return 'extension \$${validatedClassName}WrappedExtension on $validatedClassName { $validatedClassName copyWith({$spittedPropertiesJoined}) { return $validatedClassName($splittedPropertiesNamesContent);}}';
+    return 'extension \$${validatedClassName}WrappedExtension on $validatedClassName { $validatedClassName copyWithWrapped({$spittedPropertiesJoined}) { return $validatedClassName($splittedPropertiesNamesContent);}}';
   }
 
   String generateGetHashContent(


### PR DESCRIPTION
Make the ClassNameWrappedExtension have different method name than the ClassNameExtension.