### PR TITLE
Added the 'expose_http_client' flag

### DIFF
--- a/lib/src/code_generators/swagger_additions_generator.dart
+++ b/lib/src/code_generators/swagger_additions_generator.dart
@@ -41,6 +41,7 @@ class SwaggerAdditionsGenerator extends SwaggerGeneratorBase {
     String swaggerFileName,
     bool hasModels,
     bool buildOnlyModels,
+    bool exposeHttpClient,
     bool hasEnums,
     bool separateModels,
   ) {
@@ -49,12 +50,18 @@ class SwaggerAdditionsGenerator extends SwaggerGeneratorBase {
     final chopperPartImport =
         buildOnlyModels ? '' : "part '$swaggerFileName.swagger.chopper.dart';";
 
+    final httpImport = exposeHttpClient
+        ? '''
+import 'package:http/http.dart' as http;
+'''
+        : '';
+
     final chopperImports = buildOnlyModels
         ? ''
         : '''import 'package:chopper/chopper.dart';
 
 import 'client_mapping.dart';
-import 'package:chopper/chopper.dart' as chopper;''';
+import 'package:chopper/chopper.dart' as chopper;$httpImport''';
 
     final enumsImport = hasEnums
         ? "import '$swaggerFileName.enums.swagger.dart' as enums;"

--- a/lib/src/models/generator_options.dart
+++ b/lib/src/models/generator_options.dart
@@ -12,6 +12,7 @@ class GeneratorOptions {
     this.separateModels = false,
     this.classesWithNullabeLists = const [],
     this.buildOnlyModels = false,
+    this.exposeHttpClient = false,
     this.defaultValuesMap = const <DefaultValueMap>[],
     this.defaultHeaderValuesMap = const <DefaultHeaderValueMap>[],
     this.responseOverrideValueMap = const <ResponseOverrideValueMap>[],
@@ -81,6 +82,9 @@ class GeneratorOptions {
 
   @JsonKey(defaultValue: false)
   final bool buildOnlyModels;
+
+  @JsonKey(defaultValue: false)
+  final bool exposeHttpClient;
 
   @JsonKey(defaultValue: '')
   final String modelPostfix;

--- a/lib/src/models/generator_options.g2.dart
+++ b/lib/src/models/generator_options.g2.dart
@@ -17,6 +17,7 @@ GeneratorOptions _$GeneratorOptionsFromJson(Map json) => GeneratorOptions(
                   .toList() ??
               [],
       buildOnlyModels: json['build_only_models'] as bool? ?? false,
+      exposeHttpClient: json['expose_http_client'] as bool? ?? false,
       defaultValuesMap: (json['default_values_map'] as List<dynamic>?)
               ?.map((e) =>
                   DefaultValueMap.fromJson(Map<String, dynamic>.from(e as Map)))
@@ -85,6 +86,7 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
       'classes_with_nullabe_lists': instance.classesWithNullabeLists,
       'cut_from_model_names': instance.cutFromModelNames,
       'build_only_models': instance.buildOnlyModels,
+      'expose_http_client': instance.exposeHttpClient,
       'model_postfix': instance.modelPostfix,
       'default_values_map': instance.defaultValuesMap,
       'default_header_values_map': instance.defaultHeaderValuesMap,

--- a/lib/src/swagger_code_generator.dart
+++ b/lib/src/swagger_code_generator.dart
@@ -40,6 +40,7 @@ class SwaggerCodeGenerator {
     String swaggerFileName,
     bool hasModels,
     bool buildOnlyModels,
+    bool exposeHttpClient,
     bool hasEnums,
     bool separateModels,
     GeneratorOptions options,
@@ -48,6 +49,7 @@ class SwaggerCodeGenerator {
           swaggerFileName,
           hasModels,
           buildOnlyModels,
+          exposeHttpClient,
           hasEnums,
           separateModels);
 
@@ -81,10 +83,10 @@ class SwaggerCodeGenerator {
   String generateRequests(SwaggerRoot root, String className, String fileName,
           GeneratorOptions options) =>
       _getSwaggerRequestsGenerator(root, options).generate(
-        swaggerRoot: root,
-        className: className,
-        fileName: fileName,
-      );
+          swaggerRoot: root,
+          className: className,
+          fileName: fileName,
+          exposeHttpClient: options.exposeHttpClient);
 
   String generateCustomJsonConverter(
           String fileName, GeneratorOptions options) =>

--- a/lib/swagger_dart_code_generator.dart
+++ b/lib/swagger_dart_code_generator.dart
@@ -192,6 +192,7 @@ class SwaggerDartCodeGenerator implements Builder {
       fileNameWithoutExtension,
       models.isNotEmpty,
       options.buildOnlyModels,
+      options.exposeHttpClient,
       enums.isNotEmpty,
       options.separateModels,
       options,

--- a/test/generator_tests/additions_generator_test.dart
+++ b/test/generator_tests/additions_generator_test.dart
@@ -17,6 +17,8 @@ void main() {
 
       expect(result, contains("part 'swagger.fileName.swagger.chopper.dart';"));
       expect(result, contains("part 'swagger.fileName.swagger.g.dart';"));
+      expect(
+          result, isNot(contains("import 'package:http/http.dart' as http;")));
     });
 
     test('Should generate correct imports', () {
@@ -25,6 +27,13 @@ void main() {
 
       expect(result,
           contains("import 'swagger.fileName.enums.swagger.dart' as enums;"));
+    });
+
+    test('Should generate correct imports', () {
+      final result = generator.generateImportsContent(
+          'swagger.fileName', true, false, true, true, false);
+
+      expect(result, contains("import 'package:http/http.dart' as http;"));
     });
 
     test('Should generate indexes file', () {

--- a/test/generator_tests/additions_generator_test.dart
+++ b/test/generator_tests/additions_generator_test.dart
@@ -13,7 +13,7 @@ void main() {
 
     test('Should generate correct imports', () {
       final result = generator.generateImportsContent(
-          'swagger.fileName', true, false, false, false);
+          'swagger.fileName', true, false, false, false, false);
 
       expect(result, contains("part 'swagger.fileName.swagger.chopper.dart';"));
       expect(result, contains("part 'swagger.fileName.swagger.g.dart';"));
@@ -21,7 +21,7 @@ void main() {
 
     test('Should generate correct imports', () {
       final result = generator.generateImportsContent(
-          'swagger.fileName', true, false, true, false);
+          'swagger.fileName', true, false, false, true, false);
 
       expect(result,
           contains("import 'swagger.fileName.enums.swagger.dart' as enums;"));

--- a/test/generator_tests/requests_generator_test.dart
+++ b/test/generator_tests/requests_generator_test.dart
@@ -43,7 +43,7 @@ void main() {
         swaggerRoot: root,
         className: 'CarsService',
         fileName: 'cars_service',
-        exposeHttpClient: false,
+        exposeHttpClient: true,
       );
 
       expect(result2, contains('Future<chopper.Response<CarModel>>'));
@@ -55,6 +55,8 @@ void main() {
           result,
           contains(
               '{@Part() required String filename, @PartFile() required List<int> file}'));
+      expect(result, isNot(contains('      client: httpClient,\n')));
+      expect(result2, contains('      client: httpClient,\n'));
     });
   });
 }

--- a/test/generator_tests/requests_generator_test.dart
+++ b/test/generator_tests/requests_generator_test.dart
@@ -25,6 +25,7 @@ void main() {
         swaggerRoot: root,
         className: 'CarsService',
         fileName: 'cars_service',
+        exposeHttpClient: false,
       );
 
       final result2 = SwaggerRequestsGenerator(GeneratorOptions(
@@ -42,13 +43,18 @@ void main() {
         swaggerRoot: root,
         className: 'CarsService',
         fileName: 'cars_service',
+        exposeHttpClient: false,
       );
 
       expect(result2, contains('Future<chopper.Response<CarModel>>'));
       expect(result, contains('Future<chopper.Response<CarModel>> carsGet'));
       expect(result, contains('Future<chopper.Response<CarModel>> carsPost'));
-      expect(result, contains('Future<chopper.Response<CarModel>> carsMultipartPost'));
-      expect(result, contains('{@Part() required String filename, @PartFile() required List<int> file}'));
+      expect(result,
+          contains('Future<chopper.Response<CarModel>> carsMultipartPost'));
+      expect(
+          result,
+          contains(
+              '{@Part() required String filename, @PartFile() required List<int> file}'));
     });
   });
 }


### PR DESCRIPTION
I want to be able to supply a http client to the generated code. This is useful for configuring things like proxies but also for unit testing.

I've added a build option `expose_http_client` that you can add in the `build.yaml`.

With the flag set to `false` (default), the code remains exactly as it was before adding this feature.
When it's enabled the following is generate:
```dart
  static Api create(
      {ChopperClient? client,
      Authenticator? authenticator,
      String? baseUrl,
      Iterable<dynamic>? interceptors,
      http.Client? httpClient}) {
    if (client != null) {
      return _$Api(client);
    }

    final newClient = ChopperClient(
        services: [_$Api()],
        converter: $JsonSerializableConverter(),
        interceptors: interceptors ?? [],
        authenticator: authenticator,
        client: httpClient,
        baseUrl: baseUrl ?? 'http://');
    return _$Api(newClient);
  }
```

The reason why I put this behind a flag is because you need a dependency to `http` when you want to accept `http.Client` as a parameter, which would be a breaking change.
