### PR TITLE
Fixed lowercase enum properties

### DIFF
--- a/lib/src/code_generators/swagger_enums_generator.dart
+++ b/lib/src/code_generators/swagger_enums_generator.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:recase/recase.dart';
 import 'package:swagger_dart_code_generator/src/code_generators/constants.dart';
 import 'package:swagger_dart_code_generator/src/code_generators/swagger_generator_base.dart';
@@ -9,7 +10,6 @@ import 'package:swagger_dart_code_generator/src/swagger_models/requests/swagger_
 import 'package:swagger_dart_code_generator/src/swagger_models/responses/swagger_schema.dart';
 import 'package:swagger_dart_code_generator/src/swagger_models/swagger_path.dart';
 import 'package:swagger_dart_code_generator/src/swagger_models/swagger_root.dart';
-import 'package:collection/collection.dart';
 
 abstract class SwaggerEnumsGenerator extends SwaggerGeneratorBase {
   final GeneratorOptions _options;
@@ -392,8 +392,8 @@ $enumMap
         var result = '';
 
         schema.items?.properties.forEach((key, value) {
-          result +=
-              generateEnumContentIfPossible(value, '$className\$Item$key');
+          result += generateEnumContentIfPossible(
+              value, '$className\$Item${key.pascalCase}');
         });
 
         return result;


### PR DESCRIPTION
### Problem
Our Swagger property:
```
"Company": {
    "type": "object",
    "properties": {
        "id": {
            "title": "ID",
            "type": "integer",
            "readOnly": true
        },
        "customers": {
            "type": "array",
            "items": {
                "type": "object",
                "properties": {
                    "id": {
                        "title": "ID",
                        "type": "integer",
                        "readOnly": true
                    },
                    "currency": {
                        "title": "Currency",
                        "description": "The currency of the customer",
                        "type": "string",
                        "enum": [
                            "USD",
                        ]
                    },
                }
            },
            "readOnly": true
        },
    }
},
```
Would result in enums.swagger.dart:

`const $Company$Customers$ItemcurrencyMap`
The name of the property after $Item should be pascal case, because in models.swagger.dart, this is also imported like that. 
Current usage of the enum in models.swagger.dart:
`const $Company$Customers$ItemCurrencyMap`

This will result in "undefined variable".

### Solution
Capitalize the key of the enum when generating the enums.swagger.dart