### PR TITLE
Added launch.json and tasks.json for debugging in VS Code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Swagger Generator",
+      "cwd": "example",
+      "request": "launch",
+      "program": ".dart_tool/build/entrypoint/build.dart",
+      "type": "dart",
+      "args": ["build", "--delete-conflicting-outputs"],
+      "preLaunchTask": "remove_output"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "remove_output",
+      "command": "rm -rf example/lib/swagger_generated_code",
+      "type": "shell",
+      "problemMatcher": ["$tsc"],
+      "presentation": {
+        "reveal": "silent"
+      },
+      "group": "build"
+    }
+  ]
+}


### PR DESCRIPTION
To make debugging easier for future contributors. I suggest to add a launch config for VS code.

This allows then with `F5` the debugging of the code using breakpoints.

The command which is executed is: 
`flutter pub run build_runner build --delete-conflicting-outputs`

Why is the program called `.dart_tool/build/entrypoint/build.dart` in launch.json and not `flutter pub run build_runner`?
https://stackoverflow.com/questions/69566998/how-to-debug-flutter-build-runner-build-in-vs-code

The `preLaunchTask` is defined in `.vscode/tasks.json`. This removes the previous output folder, because there are usually no changes in the example folder and the build_runner would not build anything otherwise.