### PR TITLE
imp: support latest version of markdown

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ environment:
 dependencies:
   build: ^2.2.1
   path: ^1.8.0
-  markdown: ^5.0.0
+  markdown: '>=5.0.0 <8.0.0'
   recase: ^4.0.0
   json_annotation: ^4.4.0
   universal_io: ^2.0.4


### PR DESCRIPTION
Currently we get an conflict if using packages that require markdown 6.0.0, or 7.0.0. With this change the package will support the latest version of the markdown plugin.