### PR TITLE
Fixed #553 Generation putIfAbsent for names begins with "Map"

### DIFF
--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -305,7 +305,7 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
   bool _isValidModelName(String modelName) {
     if (modelName.isEmpty ||
         kBasicTypes.contains(modelName) ||
-        modelName.startsWith(kMap)) {
+        modelName.startsWith('$kMap<')) {
       return false;
     }
     return true;


### PR DESCRIPTION
Fix #553 Generation of `putIfAbsent` methods for models with name begins with _Map_