### PR TITLE
Add support for overriding http client

### DIFF
--- a/lib/src/code_generators/swagger_additions_generator.dart
+++ b/lib/src/code_generators/swagger_additions_generator.dart
@@ -59,6 +59,7 @@ class SwaggerAdditionsGenerator extends SwaggerGeneratorBase {
 
 import 'client_mapping.dart';
 import 'dart:async';
+import 'package:http/http.dart' as http;
 import 'package:chopper/chopper.dart' as chopper;''';
 
     final enumsImport = hasEnums

--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -88,6 +88,13 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
               (p) =>
           p
             ..named = true
+            ..type = Reference('http.Client?')
+            ..name = 'httpClient',
+        ))
+        ..optionalParameters.add(Parameter(
+              (p) =>
+          p
+            ..named = true
             ..type = Reference('Authenticator?')
             ..name = 'authenticator',
         ))
@@ -1247,6 +1254,7 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
       services: [_\$$className()],
       $converterString
       interceptors: interceptors ?? [],
+      client: httpClient,
       authenticator: authenticator,
       $baseUrlString);
     return _\$$className(newClient);


### PR DESCRIPTION
Adds support for overriding the `http.Client` used for the `ChopperClient` when creating the API.

This is useful as you may want to use the `MockClient` from `http/testing` but keep all the other configuration in place.

As a contrived example:

```dart
// my_app.dart
Provider<PetsApi>.value(
    // Use existing client if it exists
    value: PetsApi.create( client: context.read<Client?>(), ... ),
    child: MaterialApp( ... )
)
```

This would allow you to write a test like:

```dart
// my_app_test.dart
tester.pumpWidget(
  // Inject our mock client
  Provider<Client>(
    value: MockClient( ... ),
    child: MyApp()
  )
)
```

to ensure things like your `interceptors` are working correctly.

I think this also might address #614 to an extent.

