### PR TITLE
Bump http to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Bump `package:http` to `^1.0.0`
+
 # 2.11.8
 
 * Fixed generation of fields of some models

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Bump `package:http` to `^1.0.0`
+* Bump minimum dart version to `^3.0.0`
 
 # 2.11.8
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,8 @@
 include: package:lints/recommended.yaml
 
 analyzer:
+  language:
+    strict-casts: true
   exclude:
     - example/**/*.dart
     - lib/**/*.g2.dart

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -3,8 +3,8 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
   exclude:
     - example/**/*.dart
     - lib/**/*.g2.dart

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,16 +4,16 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   chopper: ^6.1.1
   json_annotation: ^4.8.0
-  
+
 dev_dependencies:
   swagger_dart_code_generator:
     path: ../
   chopper_generator: ^6.0.0
   build_runner: ^2.3.3
   json_serializable: ^6.6.1
-  lints: ^1.0.1
+  lints: ^2.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   collection: ^1.15.0
   dart_style: ^2.2.1
   code_builder: ^4.1.0
-  http: ^0.13.4
+  http: ^1.0.0
   yaml: ^3.1.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ description: Have you been turned into a problem with writing code for Http
   functionality you have been looking for.
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   build: ^2.2.1


### PR DESCRIPTION
Old version of http was blocking dependency upgrades. New http requires dart 3, so this package also needs now to require dart 3. This is a good occasion to also resolve #607. Leaving the changelog entry as unreleased to decide on the new version (most likely 3.0.0) and to possibly add new features while we are at a major version bump.