### PR TITLE
Add support for `enums_case_sensitive` option

### DIFF
--- a/lib/src/code_generators/enum_model.dart
+++ b/lib/src/code_generators/enum_model.dart
@@ -100,8 +100,12 @@ const $name(this.value);
     return '$result(${isInteger ? fieldValue : '\'$fieldValue\''})';
   }
 
-  String generateFromJsonToJson() {
+  String generateFromJsonToJson([bool caseSensitive = true]) {
     final type = isInteger ? 'int' : 'String';
+
+    String enumParse = caseSensitive
+        ? 'return enums.$name.values.firstWhereOrNull((e) => e.value == ${name.camelCase}) ?? defaultValue ?? enums.$name.swaggerGeneratedUnknown'
+        : 'return enums.$name.values.firstWhereOrNull((e) => e.value.toString().toLowerCase() == ${name.camelCase}?.toString()?.toLowerCase()) ?? defaultValue ?? enums.$name.swaggerGeneratedUnknown';
 
     return '''
 $type? ${name.camelCase}ToJson(enums.$name? ${name.camelCase}) {
@@ -113,7 +117,7 @@ enums.$name ${name.camelCase}FromJson(
   [enums.$name? defaultValue,]
   ) {
 
-return enums.$name.values.firstWhereOrNull((e) => e.value == ${name.camelCase}) ?? defaultValue ?? enums.$name.swaggerGeneratedUnknown;
+$enumParse;
 }
 
 

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -251,7 +251,9 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
     required bool generateEnumsMethods,
   }) {
     final allEnumsString = generateEnumsMethods
-        ? allEnums.map((e) => e.generateFromJsonToJson()).join()
+        ? allEnums
+            .map((e) => e.generateFromJsonToJson(options.enumsCaseSensitive))
+            .join()
         : '';
 
     final allEnumListNames = getAllListEnumNames(root);


### PR DESCRIPTION
There is an option in the [configuration docs](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator#configuration) for `enums_case_sensitive` that reads:

>If value is false, 'enumValue' will be defined like Enum.enumValue even it's json key equals 'ENUMVALUE'

As far as I could tell, this option was parsed but never actually used in the codebase. Also from my testing, the option did nothing.

This PR adds support for this option so when it is set to `false` (the non-default) it will generate a case insensitive version of each enum's `enumFromJson()`.

Meaning `myEnumFromJson('foo') == myEnumFromJson('FOO') == MyEnum.foo`.
