### PR TITLE
Improve support for multipart files

### DIFF
--- a/lib/src/code_generators/swagger_additions_generator.dart
+++ b/lib/src/code_generators/swagger_additions_generator.dart
@@ -60,6 +60,7 @@ class SwaggerAdditionsGenerator extends SwaggerGeneratorBase {
 import 'client_mapping.dart';
 import 'dart:async';
 import 'package:http/http.dart' as http;
+import 'package:http/http.dart' show MultipartFile;
 import 'package:chopper/chopper.dart' as chopper;''';
 
     final enumsImport = hasEnums

--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -92,8 +92,7 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
             ..name = 'httpClient',
         ))
         ..optionalParameters.add(Parameter(
-              (p) =>
-          p
+          (p) => p
             ..named = true
             ..type = Reference('Authenticator?')
             ..name = 'authenticator',
@@ -761,24 +760,28 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
 
         // otherwise no request scheme is defined, we provide every param as a separate param.
         schema?.properties.forEach((key, value) {
-          if ((value.type == 'string' && value.format == 'binary') ||
-              value.type == 'file') {
-            final isRequired = schema!.required.contains(key);
-            final typeName =
-                _mapParameterName(value.type, value.format, modelPostfix);
+          isBinary(SwaggerSchema? value) =>
+              (value?.type == 'string' && value?.format == 'binary') ||
+              value?.type == 'file';
+          if ((isBinary(value) ||
+              value.type == 'array' && isBinary(value.items))) {
+            final isRequired =
+                value.type == 'array' || schema!.required.contains(key);
+            String typeRef = isRequired
+                ? options.multipartFileType
+                : options.multipartFileType.makeNullable();
+
+            if (value.type == 'array') {
+              typeRef = 'List<$typeRef>';
+            }
+
             result.add(
               Parameter(
                 (p) => p
                   ..name = key
                   ..named = true
                   ..required = isRequired
-                  ..type = Reference(
-                    isRequired
-                        ? options.multipartFileType
-                        : options.multipartFileType.makeNullable(),
-                  )
-                  ..type = Reference(typeName.makeNullable())
-                  ..named = true
+                  ..type = Reference(typeRef)
                   ..annotations.add(
                     refer(kPartFile.pascalCase).call([]),
                   ),


### PR DESCRIPTION
Adds support for array multi-part form data attachments.

Take for example the following endpoint:

```yaml
  /api/attachments/upload:
    post:
      operationId: uploadFile
      parameters:
        - name: productId
          required: true
          in: query
          description: Product to associate the files to
          schema: {}
      requestBody:
        required: true
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                files:
                  type: array
                  items:
                    type: string
                    format: binary
```

We can post several files at once to the given product.

The current generator has a few issues preventing this:
1. The current generator incorrectly adds array items as `Part` items instead of `PartFile`. 
2. If we set `multipart_file_type: 'MultipartFile'` in our build.yaml the generated code would be invalid as `http` is an aliased import.
3. Lists of attachments in general are not supported

```dart
  @Post(
    path: '/api/attachments/upload',
    optionalBody: true,
  )
  @Multipart()
  Future<chopper.Response<List<Attachment>>> _apiAttachmentsUploadPost({
    @Query('productId') required Object? productId,
    @PartFile() required List<MultipartFile> files,
  });
```

Meaning we can now do our bulk upload:

```dart
apiAttachmentsUploadPost(productId: 'product-1', files: [
   MultipartFile.fromBytes('files', file1.bytes, filename: file1.name),
   MultipartFile.fromBytes('files', file2.bytes, filename: file2.name),
]);
```