### PR TITLE
Ability to generate custom annotations for any model properties

### DIFF
--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -1009,7 +1009,32 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     typeName =
         nullable(typeName, className, requiredProperties, propertyKey, prop);
 
-    return '\t$jsonKeyContent  final $typeName $propertyName;${unknownEnumValue.fromJson}';
+    var jsonCustomAnnotationContent = '';
+
+    var rawJson = prop.rawJson;
+    if (null != rawJson){
+      for(var customAnnotation in options.customAnnotations)
+      {
+        if (rawJson.containsKey(customAnnotation.swaggerKey))
+        {
+          var jsonPropKeyValue = rawJson[customAnnotation.swaggerKey];
+          if (null != jsonPropKeyValue){
+            jsonCustomAnnotationContent +=
+              "\t@${customAnnotation.typeName}(";
+            if (jsonPropKeyValue is String)
+            {
+              jsonCustomAnnotationContent += "'${jsonPropKeyValue}'";
+            } else {
+              jsonCustomAnnotationContent += "${jsonPropKeyValue}";
+            }
+            jsonCustomAnnotationContent += ")\n";
+          }
+        }
+      }
+    }
+
+
+    return '\t$jsonKeyContent$jsonCustomAnnotationContent final $typeName $propertyName;${unknownEnumValue.fromJson}';
   }
 
   String generatePropertyContentByType(

--- a/lib/src/models/generator_options.dart
+++ b/lib/src/models/generator_options.dart
@@ -37,6 +37,7 @@ class GeneratorOptions {
     this.overridenModels = const [],
     this.generateToJsonFor = const [],
     this.multipartFileType = 'List<int>',
+    this.customAnnotations = const[]
   });
 
   /// Build options from a JSON map.
@@ -136,6 +137,9 @@ class GeneratorOptions {
   @JsonKey(defaultValue: [])
   final List<String> excludePaths;
 
+  @JsonKey(defaultValue: <CustomAnnotationMap>[])
+  final List<CustomAnnotationMap> customAnnotations;
+  
   /// Convert this options instance to JSON.
   Map<String, dynamic> toJson() => _$GeneratorOptionsToJson(this);
 }
@@ -194,4 +198,22 @@ class DefaultHeaderValueMap {
 
   factory DefaultHeaderValueMap.fromJson(Map<String, dynamic> json) =>
       _$DefaultHeaderValueMapFromJson(json);
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class CustomAnnotationMap {
+  CustomAnnotationMap({required this.typeName, required this.swaggerKey});
+
+  /// Build a default value map from a JSON map.
+  factory CustomAnnotationMap.fromJson(Map<String, dynamic> json) =>
+      _$CustomAnnotationMapFromJson(json);
+
+  @JsonKey(defaultValue: '')
+  final String typeName;
+
+  @JsonKey(defaultValue: '')
+  final String swaggerKey;
+
+  /// Convert this default value map instance to JSON.
+  Map<String, dynamic> toJson() => _$CustomAnnotationMapToJson(this);
 }

--- a/lib/src/models/generator_options.g2.dart
+++ b/lib/src/models/generator_options.g2.dart
@@ -84,6 +84,11 @@ GeneratorOptions _$GeneratorOptionsFromJson(Map json) => GeneratorOptions(
               .toList() ??
           [],
       multipartFileType: json['multipart_file_type'] as String? ?? 'List<int>',
+      customAnnotations: (json['custom_annotations'] as List<dynamic>?)
+              ?.map((e) => CustomAnnotationMap.fromJson(
+                  Map<String, dynamic>.from(e as Map)))
+              .toList() ??
+          [],
     );
 
 Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
@@ -120,6 +125,7 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
       'import_paths': instance.importPaths,
       'custom_return_type': instance.customReturnType,
       'exclude_paths': instance.excludePaths,
+      'custom_annotations': instance.customAnnotations,
     };
 
 DefaultValueMap _$DefaultValueMapFromJson(Map<String, dynamic> json) =>
@@ -162,4 +168,17 @@ Map<String, dynamic> _$DefaultHeaderValueMapToJson(
     <String, dynamic>{
       'header_name': instance.headerName,
       'default_value': instance.defaultValue,
+    };
+
+CustomAnnotationMap _$CustomAnnotationMapFromJson(Map<String, dynamic> json) =>
+    CustomAnnotationMap(
+      typeName: json['type_name'] as String? ?? '',
+      swaggerKey: json['swagger_key'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$CustomAnnotationMapToJson(
+        CustomAnnotationMap instance) =>
+    <String, dynamic>{
+      'type_name': instance.typeName,
+      'swagger_key': instance.swaggerKey,
     };

--- a/lib/src/swagger_models/responses/swagger_schema.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.dart
@@ -24,7 +24,10 @@ class SwaggerSchema {
     this.isNullable = false,
     this.hasAdditionalProperties = false,
     this.msEnum,
+    this.rawJson
   });
+
+  Map<String, dynamic>? rawJson;
 
   @JsonKey(name: 'type', defaultValue: '')
   String type;
@@ -98,9 +101,11 @@ class SwaggerSchema {
   bool hasAdditionalProperties;
 
   List<String>? enumNames;
+  
 
   factory SwaggerSchema.fromJson(Map<String, dynamic> json) =>
       _$SwaggerSchemaFromJson(json)
+        ..rawJson = json
         ..enumNames = ((json[kEnumNames] ?? json[kEnumVarnames]) as List?)
             ?.map((e) => e as String)
             .toList()

--- a/lib/src/swagger_models/responses/swagger_schema.g2.dart
+++ b/lib/src/swagger_models/responses/swagger_schema.g2.dart
@@ -51,10 +51,12 @@ SwaggerSchema _$SwaggerSchemaFromJson(Map<String, dynamic> json) =>
       msEnum: json['x-ms-enum'] == null
           ? null
           : MsEnum.fromJson(json['x-ms-enum'] as Map<String, dynamic>),
+      rawJson: json['rawJson'] as Map<String, dynamic>?,
     );
 
 Map<String, dynamic> _$SwaggerSchemaToJson(SwaggerSchema instance) =>
     <String, dynamic>{
+      'rawJson': instance.rawJson,
       'type': instance.type,
       'format': instance.format,
       'default': instance.defaultValue,


### PR DESCRIPTION
I needed access to more swagger schema meta-data, such as maximum allowed string lengths, numeric ranges, formats for strings, such as Uuid, etc - which is currently not being produced by swagger-dart-code-generator.

Example:

```
 "Category": {
      "type": "object",
      "properties": {
        "id": {
          "type": "integer",
          "format": "int64"
        },
        "name": {
          "type": "string",
          "maxLength" 1024
        }
      }
    },
```

should produce

```
  @JsonKey(name: 'id', includeIfNull: false)
  @Format('int64')
  final int? id;

  @JsonKey(name: 'name', includeIfNull: false, defaultValue: '')
  @MaxLength(1024)
  final String? name;
```

I have implemented an extensible mechanism which allows you to configure the 'options' in build.yaml, keys to look for in the swagger 'properties' schema, which then produce code custom annotation code when these keys are found.

The developer is required to implement and import the simple custom annotation classes, and import them into the generated code using the build.yaml 'import_paths: []' option.

Here is an demonstration of what to add to the example project build.yaml to produce the above custom annotation output.

```
          import_paths: 
            - package:example/custom_annotations/format.dart
            - package:example/custom_annotations/max_length.dart
          custom_annotations:
            - type_name: 'MinLength'
              swagger_key: 'minLength'
            - type_name: 'MaxLength'
              swagger_key: 'maxLength'
            - type_name: 'Minimum'
              swagger_key: 'minimum'
            - type_name: 'Maximum'
              swagger_key: 'maximum'
            - type_name: 'Format'
              swagger_key: 'format'

```
I have committed an extension to the example with this PR