### PR TITLE
Add two new options to use swagger-dart-code-generator as entity generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
+
+# 2.11.12
+
+* Add new genAttributeNames and genTableNames options to generate static const attrXXX and tablename for models
+
+# 2.11.11
+
+* Fixed generation of fields of some models
+
 # 2.11.10
 
 * Bump `package:http` to `^1.0.0`
 * Bump minimum dart version to `^3.0.0`
 * Fixed #625 generation of query enum parameters
-
-# 2.11.11
-
-* Fixed generation of fields of some models
 
 # 2.11.7
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ targets:
 | `overriden_models` | `-` | `false` | List of manually written models that will replace the generated one. These models will not be generated. |
 | `use_path_for_request_names` | `true` | `false` | Can be false only if all requests has unique `operationId`. It gives readable names for requests. |
 | `addBasePathToRequests` | `true` | `false` | Add swagger base path to all request path. |
+| `gen_attribute_names` | `false` | `false` | Generate for all model attributes a static const attrXXX with the name. |
+| `gen_table_names` | `false` | `false` | Add the tablename to the model file with static const tablename. |
 
 
 It's important to remember that, by default, [build](https://github.com/dart-lang/build) will follow [Dart's package layout conventions](https://dart.dev/tools/pub/package-layout), meaning that only some folders will be considered to parse the input files. So, if you want to reference files from a folder other than `lib/`, make sure you've included it on `sources`:

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -1110,6 +1110,10 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
 
       final basicTypesMap = generateBasicTypesMapFromSchemas(root);
 
+      if (options.genAttributeNames && propertyName.isNotEmpty) {
+        results.add(generatePropertyAttrName(propertyName));
+      }
+
       propertyName = getValidatedParameterName(propertyName).asParameterName();
 
       if (propertyName.isEmpty) {
@@ -1117,10 +1121,6 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       }
 
       propertyName = getParameterName(propertyName, propertyNames);
-
-      if (options.genAttributeNames) {
-        results.add(generatePropertyAttrName(propertyName));
-      }
 
       propertyNames.add(propertyName);
       if (prop.type.isNotEmpty) {

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -37,6 +37,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
     List<String> allEnumNames,
     List<String> allEnumListNames,
     Map<String, SwaggerSchema> allClasses,
+    String tableName,
   ) {
     if (options.overridenModels.contains(getValidatedClassName(className))) {
       return '';
@@ -115,6 +116,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
           allEnumNames,
           allEnumListNames,
           allClasses,
+          tableName,
         );
 
         return 'typedef $className = List<$itemClassName>; $resultClass';
@@ -133,6 +135,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
       allEnumNames,
       allEnumListNames,
       allClasses,
+      tableName,
     );
   }
 
@@ -286,6 +289,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
         allEnums.map((e) => e.name).toList(),
         allEnumListNames,
         classes,
+        className,
       );
     }).join('\n');
 
@@ -408,6 +412,12 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
     }
 
     return ', includeIfNull: ${options.includeIfNull}';
+  }
+
+  String generatePropertyAttrName(
+    String propertyName,
+  ) {
+    return '\tstatic const attr${propertyName.pascalCase} = \'$propertyName\';\n';
   }
 
   String generatePropertyContentByDefault(
@@ -1108,6 +1118,10 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
 
       propertyName = getParameterName(propertyName, propertyNames);
 
+      if (options.genAttributeNames) {
+        results.add(generatePropertyAttrName(propertyName));
+      }
+
       propertyNames.add(propertyName);
       if (prop.type.isNotEmpty) {
         results.add(generatePropertyContentByType(
@@ -1284,6 +1298,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     List<String> allEnumNames,
     List<String> allEnumListNames,
     Map<String, SwaggerSchema> allClasses,
+    String tableName,
   ) {
     final properties = getModelProperties(schema, schemas, allClasses);
 
@@ -1329,6 +1344,10 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       options,
     );
 
+    final tableNameConstant = options.genTableNames
+        ? '\nstatic const tableName = \'$tableName\';\n'
+        : '';
+
     final toStringOverride = options.overrideToString
         ? '''
 @override
@@ -1350,6 +1369,7 @@ class $validatedClassName{
 \t$toJson\n
 $generatedProperties
 \tstatic const fromJsonFactory = _\$${validatedClassName}FromJson;
+$tableNameConstant
 
 $equalsOverride
 

--- a/lib/src/models/generator_options.dart
+++ b/lib/src/models/generator_options.dart
@@ -37,6 +37,8 @@ class GeneratorOptions {
     this.overridenModels = const [],
     this.generateToJsonFor = const [],
     this.multipartFileType = 'List<int>',
+    this.genAttributeNames = false,
+    this.genTableNames = false,
   });
 
   /// Build options from a JSON map.
@@ -135,6 +137,12 @@ class GeneratorOptions {
 
   @JsonKey(defaultValue: [])
   final List<String> excludePaths;
+
+  @JsonKey(defaultValue: false)
+  final bool genAttributeNames;
+
+  @JsonKey(defaultValue: false)
+  final bool genTableNames;
 
   /// Convert this options instance to JSON.
   Map<String, dynamic> toJson() => _$GeneratorOptionsToJson(this);

--- a/lib/src/models/generator_options.g2.dart
+++ b/lib/src/models/generator_options.g2.dart
@@ -7,6 +7,8 @@ part of 'generator_options.dart';
 // **************************************************************************
 
 GeneratorOptions _$GeneratorOptionsFromJson(Map json) => GeneratorOptions(
+      genAttributeNames: json['gen_attribute_names'] as bool? ?? false,
+      genTableNames: json['gen_table_names'] as bool? ?? false,
       withBaseUrl: json['with_base_url'] as bool? ?? true,
       addBasePathToRequests:
           json['add_base_path_to_requests'] as bool? ?? false,
@@ -88,6 +90,8 @@ GeneratorOptions _$GeneratorOptionsFromJson(Map json) => GeneratorOptions(
 
 Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
     <String, dynamic>{
+      'gen_attribute_names': instance.genAttributeNames,
+      'gen_table_names': instance.genTableNames,
       'use_path_for_request_names': instance.usePathForRequestNames,
       'with_base_url': instance.withBaseUrl,
       'add_base_path_to_requests': instance.addBasePathToRequests,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: swagger_dart_code_generator
 
-version: 2.11.10
+version: 2.11.12
 
 homepage: https://github.com/epam-cross-platform-lab/swagger-dart-code-generator
 repository: https://github.com/epam-cross-platform-lab/swagger-dart-code-generator

--- a/test/generator_tests/models_generator_test.dart
+++ b/test/generator_tests/models_generator_test.dart
@@ -218,6 +218,7 @@ void main() {
         [],
         [],
         {},
+        className,
       );
 
       expect(result, contains(classExpectedResult));
@@ -240,6 +241,7 @@ void main() {
         [],
         [],
         {},
+        className,
       );
 
       expect(result, contains(classExpectedResult));


### PR DESCRIPTION
Background: I am working on a flutter app with supabase as backend.
For data access I want to use the supabase_client instead of REST requests.

I created all tables in supabase and I needed a tool to create all entites based on my supabase instance.

Idea:
Use swagger-dart-code-generator to generate only models with "build_only_models: true"
but in the dart in want to generated identifiers instead of hardcoded strings.

So I added two new options:
gen_attribute_names: true
gen_table_names: true

Default values are false so that everything works as before :-)

With these new options the codegeneration looks like this:
```
@JsonSerializable(explicitToJson: true)
class CmeProfiles {
  const CmeProfiles({
    required this.id,
    required this.createdAt,
    this.updatedAt,
    required this.name,
  });

..

  static const attrId = 'id';
  static const attrCreatedAt = 'created_at';
  static const attrUpdatedAt = 'updated_at';
  static const attrName = 'name';

  static const tableName = 'cme_profiles';

...

 }
```

In the dart code I can now use generated constants, eg:
```
      final data = await Supabase.instance.client
          .from(CmeProfiles.tableName)
          .select<Map<String, dynamic>>()
          .eq(CmeProfiles.attrId, userId)
          .single()
          .withConverter((data) {
        return CmeProfiles.fromJson(data);
      });
```

