### PR TITLE
feat: handling x-www-form-urlencoded

### DIFF
--- a/lib/src/code_generators/constants.dart
+++ b/lib/src/code_generators/constants.dart
@@ -59,6 +59,7 @@ const kOptionalBody = 'optionalBody';
 const kFormData = 'formData';
 const kMultipart = 'multipart';
 const kDateTimeFormat = 'date-time';
+const kFactoryConverter = 'factoryConverter';
 
 const kDefaultBodyParameter = 'Object';
 const kField = 'Field';
@@ -89,7 +90,7 @@ const kArray = 'array';
 const kEnum = 'enum';
 const kBody = 'body';
 const kQuery = 'query';
-const kExplodedQuery ='ExplodedQuery';
+const kExplodedQuery = 'ExplodedQuery';
 const kPartFile = 'partFile';
 const kPart = 'part';
 
@@ -103,6 +104,7 @@ const kEnumNames = 'x-enumNames';
 const kEnumVarnames = 'x-enum-varnames';
 const kIsNullable = 'x-nullable';
 const kNullable = 'nullable';
+const kUrlencoded = 'urlencoded';
 
 const kServiceHeader = '''
 // **************************************************************************

--- a/lib/src/models/generator_options.dart
+++ b/lib/src/models/generator_options.dart
@@ -37,6 +37,7 @@ class GeneratorOptions {
     this.overridenModels = const [],
     this.generateToJsonFor = const [],
     this.multipartFileType = 'List<int>',
+    this.urlencodedFileType = 'Map<String, String>',
   });
 
   /// Build options from a JSON map.
@@ -63,6 +64,9 @@ class GeneratorOptions {
 
   @JsonKey(defaultValue: 'List<int>')
   final String multipartFileType;
+
+  @JsonKey(defaultValue: 'Map<String, String>')
+  final String urlencodedFileType;
 
   @JsonKey(defaultValue: true)
   final bool withConverter;

--- a/lib/src/swagger_models/requests/swagger_request.dart
+++ b/lib/src/swagger_models/requests/swagger_request.dart
@@ -94,7 +94,7 @@ RequestContent? _contentFromJson(Map<String, dynamic>? map) {
     final multipart = map['application/x-www-form-urlencoded']['schema']
         as Map<String, dynamic>;
     return RequestContent(
-        isMultipart: true, schema: SwaggerSchema.fromJson(multipart));
+        isUrlencoded: true, schema: SwaggerSchema.fromJson(multipart));
   }
 
   final content = map.values.first as Map<String, dynamic>;
@@ -106,6 +106,7 @@ RequestContent? _contentFromJson(Map<String, dynamic>? map) {
 class RequestContent {
   RequestContent({
     this.isMultipart,
+    this.isUrlencoded,
     this.schema,
   });
 
@@ -113,6 +114,7 @@ class RequestContent {
   final SwaggerSchema? schema;
 
   final bool? isMultipart;
+  final bool? isUrlencoded;
 
   Map<String, dynamic> toJson() => _$RequestContentToJson(this);
 


### PR DESCRIPTION
closes https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/issues/632

Description
Hello,

I discovered this project, and it looked awesome, so I used it in order to replace my custom API call handling functions. It works perfectly for application/json.
However, my API implements OIDC, and thus uses application/x-www-form-encoded instead of application/json.
When running, the generated code for those API routes was throwing error.
After some research, I found that this issue has already been reported, so I am proposing a fix for it.

How does it work?
Until now, x-www-form-encoded were handled the same way as multipart (in swagger_models/requests/swagger_request.dart).
I created a new parameter called isUrlencoded to dissociate these two cases, and used to it handle the right way specified (here)[https://hadrien-lejard.gitbook.io/chopper/requests#sending-application-x-www-form-urlencoded-data]

Checklist
[x] I have performed a self-review of my code
[x] My code follows the code style of this project
[x] I have commented my code, particularly in hard-to-understand areas
If you think this change may be interesting to add to [swagger-dart-code-generator](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator), I will be happy to improve the pull request based on received feedback and suggestions.

Best regards