### PR TITLE
Add `value` to `exceptionWords`

### DIFF
--- a/lib/src/exception_words.dart
+++ b/lib/src/exception_words.dart
@@ -55,4 +55,5 @@ List<String> exceptionWords = <String>[
   'try',
   'client',
   'hashCode',
+  'value'
 ];


### PR DESCRIPTION
Fixes scenarios like this:
```dart
enum Qualifier$ValueType {
  @JsonValue(null)
  swaggerGeneratedUnknown(null),

  @JsonValue('value')
  value('value'),
  @JsonValue('somevalue')
  somevalue('somevalue'),
  @JsonValue('novalue')
  novalue('novalue');

  final String? value;

  const Qualifier$ValueType(this.value);
}
```

Where enum property `value` as well as field `value` exists and lead to compile error.

Issue is also related, but does not completely fix #712