### PR TITLE
Fix type annotation for interceptors parameter in SwaggerRequestsGenerator

### DIFF
--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -118,7 +118,7 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
         ..optionalParameters.add(Parameter(
           (p) => p
             ..named = true
-            ..type = Reference('Iterable<dynamic>?')
+            ..type = Reference('List<Interceptor>?')
             ..name = 'interceptors',
         ))
         ..body = Code(body),


### PR DESCRIPTION
This fixes #749 