### PR TITLE
Feature: String format type mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ targets:
 | `use_required_attribute_for_headers` | `true` | `false` | If this option is false, generator will not add @required attribute to headers. |
 | `with_converter` | `true` | `false` | If option is true, combination of all mappings will be generated. |
 | `ignore_headers` | `false` | `false` | If option is true, headers will not be generated. |
-| `additional_headers` | `false` | `false` | List of additional headers, not specified in Swagger. Example of usage: [build.yaml](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/blob/master/example/build.yaml)
+| `additional_headers` | `false` | `false` | List of additional headers, not specified in Swagger. Example of usage: [build.yaml](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/blob/master/example/build.yaml)                                                                                                                                                                                                          
 | `enums_case_sensitive` | `true` | `false` | If value is false, 'enumValue' will be defined like Enum.enumValue even it's json key equals 'ENUMVALUE' |
 | `include_paths` | `[]` | `false` | List<String> of Regex If not empty - includes only paths matching reges |
 | `exclude_paths` | `[]` | `false` | List<String> of Regex If not empty -exclude paths matching reges |
@@ -96,6 +96,7 @@ targets:
 | `override_to_string` | `bool` | `true` | Overrides `toString()` method using `jsonEncode(this)` |
 | `generate_first_succeed_response` | `true` | `false` | If request has multiple success responses, first one will be generated. Otherwice - `dynamic` |
 | `multipart_file_type` | `List<int>` | `false` | Type if input parameter of Multipart request |
+| `overridden_formats` | `-` | `{}` | A map of custom types that are used for string properties with a given [format](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats). See example [here](#overriden-formats-implementation) |
 
 
 
@@ -152,6 +153,23 @@ targets:
               import_url: "../overriden_models_another.dart"
               overriden_models:
                 - "Result"
+```
+
+### **Overriden Formats Implementation**
+
+```yaml
+      swagger_dart_code_generator:
+        options:
+          input_folder: "input_folder/"
+          output_folder: "lib/swagger_generated_code/"
+          import_paths:
+            - "package:uuid/uuid.dart"
+          overridden_formats:
+            uuid:
+              type: Uuid
+              deserialize: Uuid.parse
+              # optional - default is toString()
+              serialize: myCustomUuidSerializeFunction
 ```
 
 ### **Response Override Value Map for requests generation**

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ targets:
 | `override_to_string` | `bool` | `true` | Overrides `toString()` method using `jsonEncode(this)` |
 | `generate_first_succeed_response` | `true` | `false` | If request has multiple success responses, first one will be generated. Otherwice - `dynamic` |
 | `multipart_file_type` | `List<int>` | `false` | Type if input parameter of Multipart request |
-| `scalars` | `-` | `{}` | A map of custom types that are used for string properties with a given [format](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats). See example [here](#overriden-formats-implementation) |
+| `scalars` | `-` | `{}` | A map of custom types that are used for string properties with a given [format](https://swagger.io/docs/specification/data-models/data-types/#format). See example [here](#overriden-formats-implementation) |
 
 
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ targets:
 | `override_to_string` | `bool` | `true` | Overrides `toString()` method using `jsonEncode(this)` |
 | `generate_first_succeed_response` | `true` | `false` | If request has multiple success responses, first one will be generated. Otherwice - `dynamic` |
 | `multipart_file_type` | `List<int>` | `false` | Type if input parameter of Multipart request |
-| `overridden_formats` | `-` | `{}` | A map of custom types that are used for string properties with a given [format](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats). See example [here](#overriden-formats-implementation) |
+| `scalars` | `-` | `{}` | A map of custom types that are used for string properties with a given [format](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats). See example [here](#overriden-formats-implementation) |
 
 
 
@@ -155,7 +155,7 @@ targets:
                 - "Result"
 ```
 
-### **Overriden Formats Implementation**
+### **Scalars Implementation**
 
 ```yaml
       swagger_dart_code_generator:
@@ -164,7 +164,7 @@ targets:
           output_folder: "lib/swagger_generated_code/"
           import_paths:
             - "package:uuid/uuid.dart"
-          overridden_formats:
+          scalars:
             uuid:
               type: Uuid
               deserialize: Uuid.parse

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ targets:
 | `use_required_attribute_for_headers` | `true` | `false` | If this option is false, generator will not add @required attribute to headers. |
 | `with_converter` | `true` | `false` | If option is true, combination of all mappings will be generated. |
 | `ignore_headers` | `false` | `false` | If option is true, headers will not be generated. |
-| `additional_headers` | `false` | `false` | List of additional headers, not specified in Swagger. Example of usage: [build.yaml](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/blob/master/example/build.yaml)                                                                                                                                                                                                          
+| `additional_headers` | `false` | `false` | List of additional headers, not specified in Swagger. Example of usage: [build.yaml](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/blob/master/example/build.yaml) |
 | `enums_case_sensitive` | `true` | `false` | If value is false, 'enumValue' will be defined like Enum.enumValue even it's json key equals 'ENUMVALUE' |
 | `include_paths` | `[]` | `false` | List<String> of Regex If not empty - includes only paths matching reges |
 | `exclude_paths` | `[]` | `false` | List<String> of Regex If not empty -exclude paths matching reges |

--- a/lib/src/code_generators/swagger_additions_generator.dart
+++ b/lib/src/code_generators/swagger_additions_generator.dart
@@ -75,6 +75,7 @@ import 'package:chopper/chopper.dart' as chopper;''';
 // ignore_for_file: type=lint
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:json_annotation/json_annotation.dart' as json;
 import 'package:collection/collection.dart';
 ${options.overrideToString ? "import 'dart:convert';" : ''}
 """);

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -447,7 +447,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
       return '';
     }
 
-    return '\n@_\$${schema.format.pascalCase}JsonConverter()';
+    return '@_\$${schema.format.pascalCase}JsonConverter()';
   }
 
   String generateJsonConverters() {
@@ -1017,6 +1017,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     required Map<String, SwaggerSchema> allClasses,
     required bool isDeprecated,
   }) {
+    final jsonConverterAnnotation = prop.items == null ? '' : generatePropertyJsonConverterAnnotation(prop.items!);
     final typeName = _generateListPropertyTypeName(
       allEnumListNames: allEnumListNames,
       allEnumNames: allEnumNames,
@@ -1066,7 +1067,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       listPropertyName = listPropertyName.makeNullable();
     }
 
-    return '$jsonKeyContent$deprecatedContent final $listPropertyName ${generateFieldName(propertyName)};${unknownEnumValue.fromJson}';
+    return '$jsonConverterAnnotation$jsonKeyContent$deprecatedContent final $listPropertyName ${generateFieldName(propertyName)};${unknownEnumValue.fromJson}';
   }
 
   String generateGeneralPropertyContent({

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -397,9 +397,9 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
       case 'boolean':
         return 'bool';
       case 'string':
-        final override = options.overriddenFormats[parameter.format];
-        if (override != null) {
-          return override.type;
+        final scalar = options.scalars[parameter.format];
+        if (scalar != null) {
+          return scalar.type;
         } else if (parameter.format == 'date-time' || parameter.format == 'date') {
           return 'DateTime';
         } else if (parameter.isEnum) {
@@ -442,7 +442,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
   }
 
   String generatePropertyJsonConverterAnnotation(SwaggerSchema schema) {
-    final override = schema.type == 'string' ? options.overriddenFormats[schema.format] : null;
+    final override = schema.type == 'string' ? options.scalars[schema.format] : null;
     if (override == null) {
       return '';
     }
@@ -451,13 +451,13 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
   }
 
   String generateJsonConverters() {
-    if (options.overriddenFormats.isEmpty) {
+    if (options.scalars.isEmpty) {
       return '';
     }
 
     var result = '';
 
-    for (final MapEntry(:key, :value) in options.overriddenFormats.entries) {
+    for (final MapEntry(:key, :value) in options.scalars.entries) {
       final className = '_\$${key.pascalCase}JsonConverter';
 
       result += '''
@@ -1362,9 +1362,9 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
   static String _mapBasicTypeToDartType(String basicType, String format, GeneratorOptions options) {
     switch (basicType.toLowerCase()) {
       case 'string':
-        final override = options.overriddenFormats[format];
-        if (override != null) {
-          return override.type;
+        final scalar = options.scalars[format];
+        if (scalar != null) {
+          return scalar.type;
         } else if (format == 'date-time' || format == 'datetime') {
           return kDateTimeType;
         } else {

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -273,6 +273,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
     required List<EnumModel> allEnums,
     required bool generateEnumsMethods,
   }) {
+    final converters = generateJsonConverters();
     final allEnumsString = generateEnumsMethods
         ? allEnums
             .map((e) => e.generateFromJsonToJson(options.enumsCaseSensitive))
@@ -319,7 +320,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
       results = results.replaceAll(' $listEnum ', ' List<$listEnum> ');
     }
 
-    return results + allEnumsString;
+    return converters + results + allEnumsString;
   }
 
   static String getValidatedParameterName(String parameterName) {
@@ -396,7 +397,10 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
       case 'boolean':
         return 'bool';
       case 'string':
-        if (parameter.format == 'date-time' || parameter.format == 'date') {
+        final override = options.overriddenFormats[parameter.format];
+        if (override != null) {
+          return override.type;
+        } else if (parameter.format == 'date-time' || parameter.format == 'date') {
           return 'DateTime';
         } else if (parameter.isEnum) {
           return 'enums.${getValidatedClassName(generateEnumName(getValidatedClassName(className), parameterName))}';
@@ -435,6 +439,41 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
     }
 
     return ', includeIfNull: ${options.includeIfNull}';
+  }
+
+  String generatePropertyJsonConverterAnnotation(SwaggerSchema schema) {
+    final override = schema.type == 'string' ? options.overriddenFormats[schema.format] : null;
+    if (override == null) {
+      return '';
+    }
+
+    return '\n@_\$${schema.format.pascalCase}JsonConverter()';
+  }
+
+  String generateJsonConverters() {
+    if (options.overriddenFormats.isEmpty) {
+      return '';
+    }
+
+    var result = '';
+
+    for (final MapEntry(:key, :value) in options.overriddenFormats.entries) {
+      final className = '_\$${key.pascalCase}JsonConverter';
+
+      result += '''
+class $className implements json.JsonConverter<${value.type}, String> {
+  const $className();
+
+  @override
+  fromJson(json) => ${value.deserialize}(json);
+
+  @override
+  toJson(json) => ${value.serialize.isEmpty ? 'json.toString()' : '${value.serialize}(json)'};
+}
+''';
+    }
+
+    return result;
   }
 
   String generatePropertyContentByDefault({
@@ -1042,6 +1081,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     required bool isDeprecated,
   }) {
     final includeIfNullString = generateIncludeIfNullString();
+    final jsonConverterAnnotation = generatePropertyJsonConverterAnnotation(prop);
 
     var jsonKeyContent =
         "@JsonKey(name: '${_validatePropertyKey(propertyKey)}'$includeIfNullString";
@@ -1103,7 +1143,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
       typeName = typeName.makeNullable();
     }
 
-    return '\t$jsonKeyContent$isDeprecatedContent  final $typeName $propertyName;${unknownEnumValue.fromJson}';
+    return '\t$jsonConverterAnnotation$jsonKeyContent$isDeprecatedContent  final $typeName $propertyName;${unknownEnumValue.fromJson}';
   }
 
   String generatePropertyContentByType(
@@ -1293,7 +1333,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
 
     allClasses.forEach((key, value) {
       if (kBasicTypes.contains(value.type.toLowerCase()) && !value.isEnum) {
-        result.addAll({key: _mapBasicTypeToDartType(value.type, value.format)});
+        result.addAll({key: _mapBasicTypeToDartType(value.type, value.format, options)});
       }
 
       if (value.type == kArray && value.items != null) {
@@ -1306,7 +1346,7 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
           final schema = allClasses[typeName];
 
           if (kBasicTypes.contains(schema?.type)) {
-            typeName = _mapBasicTypeToDartType(schema!.type, value.format);
+            typeName = _mapBasicTypeToDartType(schema!.type, value.format, options);
           } else {
             typeName = getValidatedClassName(typeName);
           }
@@ -1319,14 +1359,17 @@ static $returnType $fromJsonFunction($valueType? value) => $enumNameCamelCase$fr
     return result;
   }
 
-  static String _mapBasicTypeToDartType(String basicType, String format) {
-    if (basicType.toLowerCase() == kString &&
-        (format == 'date-time' || format == 'datetime')) {
-      return 'DateTime';
-    }
+  static String _mapBasicTypeToDartType(String basicType, String format, GeneratorOptions options) {
     switch (basicType.toLowerCase()) {
       case 'string':
-        return 'String';
+        final override = options.overriddenFormats[format];
+        if (override != null) {
+          return override.type;
+        } else if (format == 'date-time' || format == 'datetime') {
+          return kDateTimeType;
+        } else {
+          return 'String';
+        }
       case 'int':
       case 'integer':
         return 'int';

--- a/lib/src/models/generator_options.dart
+++ b/lib/src/models/generator_options.dart
@@ -34,7 +34,7 @@ class GeneratorOptions {
     this.overrideEqualsAndHashcode = true,
     this.overrideToString = true,
     this.pageWidth,
-    this.overriddenFormats = const {},
+    this.scalars = const {},
     this.overridenModels = const [],
     this.generateToJsonFor = const [],
     this.multipartFileType = 'List<int>',
@@ -56,7 +56,7 @@ class GeneratorOptions {
   final String multipartFileType;
   final String urlencodedFileType;
   final bool withConverter;
-  final Map<String, FormattedStringOverride> overriddenFormats;
+  final Map<String, CustomScalar> scalars;
   final List<OverridenModelsItem> overridenModels;
   final List<String> generateToJsonFor;
   final List<String> additionalHeaders;
@@ -182,7 +182,7 @@ class OverridenModelsItem {
 }
 
 @JsonSerializable(fieldRename: FieldRename.snake)
-class FormattedStringOverride {
+class CustomScalar {
   @JsonKey()
   final String type;
   @JsonKey()
@@ -190,14 +190,14 @@ class FormattedStringOverride {
   @JsonKey(defaultValue: '')
   final String serialize;
 
-  factory FormattedStringOverride.fromJson(Map<String, dynamic> json) =>
-      _$FormattedStringOverrideFromJson(json);
+  factory CustomScalar.fromJson(Map<String, dynamic> json) =>
+      _$CustomScalarFromJson(json);
 
-  FormattedStringOverride({
+  CustomScalar({
     required this.type,
     required this.deserialize,
     this.serialize = '',
   });
 
-  Map<String, dynamic> toJson() => _$FormattedStringOverrideToJson(this);
+  Map<String, dynamic> toJson() => _$CustomScalarToJson(this);
 }

--- a/lib/src/models/generator_options.dart
+++ b/lib/src/models/generator_options.dart
@@ -34,6 +34,7 @@ class GeneratorOptions {
     this.overrideEqualsAndHashcode = true,
     this.overrideToString = true,
     this.pageWidth,
+    this.overriddenFormats = const {},
     this.overridenModels = const [],
     this.generateToJsonFor = const [],
     this.multipartFileType = 'List<int>',
@@ -55,6 +56,7 @@ class GeneratorOptions {
   final String multipartFileType;
   final String urlencodedFileType;
   final bool withConverter;
+  final Map<String, FormattedStringOverride> overriddenFormats;
   final List<OverridenModelsItem> overridenModels;
   final List<String> generateToJsonFor;
   final List<String> additionalHeaders;
@@ -177,4 +179,25 @@ class OverridenModelsItem {
 
   factory OverridenModelsItem.fromJson(Map<String, dynamic> json) =>
       _$OverridenModelsItemFromJson(json);
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class FormattedStringOverride {
+  @JsonKey()
+  final String type;
+  @JsonKey()
+  final String deserialize;
+  @JsonKey(defaultValue: '')
+  final String serialize;
+
+  factory FormattedStringOverride.fromJson(Map<String, dynamic> json) =>
+      _$FormattedStringOverrideFromJson(json);
+
+  FormattedStringOverride({
+    required this.type,
+    required this.deserialize,
+    this.serialize = '',
+  });
+
+  Map<String, dynamic> toJson() => _$FormattedStringOverrideToJson(this);
 }

--- a/lib/src/models/generator_options.g.dart
+++ b/lib/src/models/generator_options.g.dart
@@ -75,7 +75,14 @@ GeneratorOptions _$GeneratorOptionsFromJson(Map json) => GeneratorOptions(
       overrideEqualsAndHashcode:
           json['override_equals_and_hashcode'] as bool? ?? true,
       overrideToString: json['override_to_string'] as bool? ?? true,
-      pageWidth: json['page_width'] as int?,
+      pageWidth: (json['page_width'] as num?)?.toInt(),
+      overriddenFormats: (json['overridden_formats'] as Map?)?.map(
+            (k, e) => MapEntry(
+                k as String,
+                FormattedStringOverride.fromJson(
+                    Map<String, dynamic>.from(e as Map))),
+          ) ??
+          const {},
       overridenModels: (json['overriden_models'] as List<dynamic>?)
               ?.map((e) => OverridenModelsItem.fromJson(
                   Map<String, dynamic>.from(e as Map)))
@@ -104,6 +111,7 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
       'multipart_file_type': instance.multipartFileType,
       'urlencoded_file_type': instance.urlencodedFileType,
       'with_converter': instance.withConverter,
+      'overridden_formats': instance.overriddenFormats,
       'overriden_models': instance.overridenModels,
       'generate_to_json_for': instance.generateToJsonFor,
       'additional_headers': instance.additionalHeaders,
@@ -128,7 +136,6 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
       'import_paths': instance.importPaths,
       'custom_return_type': instance.customReturnType,
       'exclude_paths': instance.excludePaths,
-      'generate_first_succeed_response': instance.generateFirstSucceedResponse,
     };
 
 DefaultValueMap _$DefaultValueMapFromJson(Map<String, dynamic> json) =>
@@ -198,4 +205,20 @@ Map<String, dynamic> _$OverridenModelsItemToJson(
       'file_name': instance.fileName,
       'overriden_models': instance.overridenModels,
       'import_url': instance.importUrl,
+    };
+
+FormattedStringOverride _$FormattedStringOverrideFromJson(
+        Map<String, dynamic> json) =>
+    FormattedStringOverride(
+      type: json['type'] as String,
+      deserialize: json['deserialize'] as String,
+      serialize: json['serialize'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$FormattedStringOverrideToJson(
+        FormattedStringOverride instance) =>
+    <String, dynamic>{
+      'type': instance.type,
+      'deserialize': instance.deserialize,
+      'serialize': instance.serialize,
     };

--- a/lib/src/models/generator_options.g.dart
+++ b/lib/src/models/generator_options.g.dart
@@ -76,11 +76,9 @@ GeneratorOptions _$GeneratorOptionsFromJson(Map json) => GeneratorOptions(
           json['override_equals_and_hashcode'] as bool? ?? true,
       overrideToString: json['override_to_string'] as bool? ?? true,
       pageWidth: (json['page_width'] as num?)?.toInt(),
-      overriddenFormats: (json['overridden_formats'] as Map?)?.map(
-            (k, e) => MapEntry(
-                k as String,
-                FormattedStringOverride.fromJson(
-                    Map<String, dynamic>.from(e as Map))),
+      scalars: (json['scalars'] as Map?)?.map(
+            (k, e) => MapEntry(k as String,
+                CustomScalar.fromJson(Map<String, dynamic>.from(e as Map))),
           ) ??
           const {},
       overridenModels: (json['overriden_models'] as List<dynamic>?)
@@ -111,7 +109,7 @@ Map<String, dynamic> _$GeneratorOptionsToJson(GeneratorOptions instance) =>
       'multipart_file_type': instance.multipartFileType,
       'urlencoded_file_type': instance.urlencodedFileType,
       'with_converter': instance.withConverter,
-      'overridden_formats': instance.overriddenFormats,
+      'scalars': instance.scalars,
       'overriden_models': instance.overridenModels,
       'generate_to_json_for': instance.generateToJsonFor,
       'additional_headers': instance.additionalHeaders,
@@ -207,16 +205,13 @@ Map<String, dynamic> _$OverridenModelsItemToJson(
       'import_url': instance.importUrl,
     };
 
-FormattedStringOverride _$FormattedStringOverrideFromJson(
-        Map<String, dynamic> json) =>
-    FormattedStringOverride(
+CustomScalar _$CustomScalarFromJson(Map<String, dynamic> json) => CustomScalar(
       type: json['type'] as String,
       deserialize: json['deserialize'] as String,
       serialize: json['serialize'] as String? ?? '',
     );
 
-Map<String, dynamic> _$FormattedStringOverrideToJson(
-        FormattedStringOverride instance) =>
+Map<String, dynamic> _$CustomScalarToJson(CustomScalar instance) =>
     <String, dynamic>{
       'type': instance.type,
       'deserialize': instance.deserialize,

--- a/test/code_examples.dart
+++ b/test/code_examples.dart
@@ -834,3 +834,56 @@ const objectWithadditionalProperties = '''
   }
 }
 ''';
+
+const String schemasWithUuidsInProperties = '''
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Some service",
+    "version": "1.0"
+  },
+  "components": {
+    "responses": {
+      "SpaResponse": {
+        "description": "Success",
+        "content": {
+          "application/json": {
+            "schema": {
+              "required": [
+                "showPageAvailable"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "Some description"
+                },
+                "showPageAvailable": {
+                  "type": "boolean",
+                  "description": "Flag indicating showPage availability"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "SpaSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Some description"
+          },
+          "showPageAvailable": {
+            "type": "boolean",
+            "description": "Flag indicating showPage availability"
+          }
+        }
+      }
+    }
+  }
+}
+''';

--- a/test/code_examples.dart
+++ b/test/code_examples.dart
@@ -858,6 +858,13 @@ const String schemasWithUuidsInProperties = '''
                   "format": "uuid",
                   "description": "Some description"
                 },
+                "list": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                },
                 "showPageAvailable": {
                   "type": "boolean",
                   "description": "Flag indicating showPage availability"

--- a/test/generator_tests/models_generator_test.dart
+++ b/test/generator_tests/models_generator_test.dart
@@ -678,6 +678,7 @@ void main() {
       );
 
       expect(result, contains(RegExp(r'''@_\$UuidJsonConverter\(\)\s*@JsonKey\(name: 'id'\)\s*final Uuid\? id;''')));
+      expect(result, contains(RegExp(r'''@_\$UuidJsonConverter\(\)\s*@JsonKey\(name: 'list', defaultValue: <Uuid>\[\]\)\s*final List<Uuid>\? list;''')));
       expect(result, contains('class _\$UuidJsonConverter implements json.JsonConverter<Uuid, String>'));
       expect(result, contains('fromJson(json) => Uuid.parse(json);'));
       expect(result, contains('toJson(json) => json.toString();'));

--- a/test/generator_tests/models_generator_test.dart
+++ b/test/generator_tests/models_generator_test.dart
@@ -678,18 +678,9 @@ void main() {
       );
 
       expect(result, contains(RegExp(r'''@_\$UuidJsonConverter\(\)\s*@JsonKey\(name: 'id'\)\s*final Uuid\? id;''')));
-      expect(result, contains('''
-class _\$UuidJsonConverter implements json.JsonConverter<Uuid, String> {
-  const _\$UuidJsonConverter();
-
-  @override
-  fromJson(json) => Uuid.parse(json);
-
-  @override
-  toJson(json) => json.toString();
-}
-'''));
-    });
+      expect(result, contains('class _\$UuidJsonConverter implements json.JsonConverter<Uuid, String>'));
+      expect(result, contains('fromJson(json) => Uuid.parse(json);'));
+      expect(result, contains('toJson(json) => json.toString();'));
     });
 
     test('Should include serialize/deserialize functions in JsonKey annotation', () {
@@ -715,16 +706,9 @@ class _\$UuidJsonConverter implements json.JsonConverter<Uuid, String> {
       );
 
       expect(result, contains(RegExp(r'''@_\$UuidJsonConverter\(\)\s*@JsonKey\(name: 'id'\)\s*final Uuid\? id;''')));
-      expect(result, contains('''
-class _\$UuidJsonConverter implements json.JsonConverter<Uuid, String> {
-  const _\$UuidJsonConverter();
-
-  @override
-  fromJson(json) => customUuidParse(json);
-
-  @override
-  toJson(json) => customUuidToString(json);
-}
-'''));
+      expect(result, contains('class _\$UuidJsonConverter implements json.JsonConverter<Uuid, String>'));
+      expect(result, contains('fromJson(json) => customUuidParse(json);'));
+      expect(result, contains('toJson(json) => customUuidToString(json);'));
+    });
   });
 }

--- a/test/generator_tests/models_generator_test.dart
+++ b/test/generator_tests/models_generator_test.dart
@@ -136,8 +136,8 @@ void main() {
           importPaths: [
             'package:uuid/uuid.dart',
           ],
-          overriddenFormats: {
-            'uuid': FormattedStringOverride(type: 'Uuid', deserialize: 'parse')
+          scalars: {
+            'uuid': CustomScalar(type: 'Uuid', deserialize: 'parse')
           }
         ),
       );
@@ -662,8 +662,8 @@ void main() {
         GeneratorOptions(
           inputFolder: '',
           outputFolder: '',
-          overriddenFormats: {
-            'uuid': FormattedStringOverride(
+          scalars: {
+            'uuid': CustomScalar(
               type: 'Uuid',
               deserialize: 'Uuid.parse',
             ),
@@ -689,8 +689,8 @@ void main() {
         GeneratorOptions(
           inputFolder: '',
           outputFolder: '',
-          overriddenFormats: {
-            'uuid': FormattedStringOverride(
+          scalars: {
+            'uuid': CustomScalar(
               type: 'Uuid',
               deserialize: 'customUuidParse',
               serialize: 'customUuidToString',


### PR DESCRIPTION
Adds the ability to specify custom types & a serialize/deserialize function for properties based on the `"format"` property.

Implementation of #719 

```yaml
      swagger_dart_code_generator:
        options:
          input_folder: "input_folder/"
          output_folder: "lib/swagger_generated_code/"
          import_paths:
            - "package:uuid/uuid.dart"
          scalars:
            uuid:
              type: Uuid
              deserialize: Uuid.parse
              # optional - default is toString()
              serialize: myCustomUuidSerializeFunction
```
