### PR TITLE
[Update] Change JsonConverter to allow dynamic type serialization

### DIFF
--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -461,7 +461,7 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
       final className = '_\$${key.pascalCase}JsonConverter';
 
       result += '''
-class $className implements json.JsonConverter<${value.type}, String> {
+class $className implements json.JsonConverter<${value.type}, dynamic> {
   const $className();
 
   @override


### PR DESCRIPTION
# PR Title:
**Allow `json.JsonConverter` to support dynamic type serialization for more flexibility**

---

## PR Description:

### Background / Problem:
When using `swagger-dart-code-generator`, the current implementation of `json.JsonConverter` forces type serialization to `String`, which limits flexibility when serializing custom types. For example, when attempting to serialize a `DateTime` object to a Unix timestamp (`int`), the code forces the output type to be `String`, leading to serialization errors.

### Proposed Solution:
This PR modifies the generated code to use `json.JsonConverter<T, dynamic>` instead of `json.JsonConverter<T, String>`. This change allows for more flexibility in serializing various types, such as serializing `DateTime` to `int` (Unix timestamp) and other custom types.

### Key Changes:
- Updated `json.JsonConverter` to support `dynamic` types instead of forcing the output to `String`.
- Ensured that the serialization logic can now handle different types, such as converting `DateTime` to a Unix timestamp (`int`).

### Test Cases:
- I have tested this change locally and confirmed that it works as expected with custom serialization (e.g., serializing `DateTime` to `int`).
- No existing functionality has been broken by this update.

### Related Issue:
This PR addresses issue [#771](https://github.com/epam-cross-platform-lab/swagger-dart-code-generator/issues/771).
