### PR TITLE
Fix: Allow 'value' to be used outside of enums by separating exception words.

### DIFF
--- a/lib/src/code_generators/enum_model.dart
+++ b/lib/src/code_generators/enum_model.dart
@@ -89,7 +89,7 @@ const $name(this.value);
 
     result = result.lower;
 
-    if (exceptionWords.contains(result)) {
+    if (exceptionWordsInEnum.contains(result)) {
       result = '\$$result';
     }
 

--- a/lib/src/code_generators/swagger_models_generator.dart
+++ b/lib/src/code_generators/swagger_models_generator.dart
@@ -348,7 +348,8 @@ abstract class SwaggerModelsGenerator extends SwaggerGeneratorBase {
       return 'enums.$result';
     }
 
-    if (exceptionWords.contains(result.camelCase) ||
+    if ((isEnum ? exceptionWordsInEnum : exceptionWords)
+            .contains(result.camelCase) ||
         kBasicTypes.contains(result.camelCase)) {
       return '\$$result';
     }

--- a/lib/src/exception_words.dart
+++ b/lib/src/exception_words.dart
@@ -55,6 +55,7 @@ List<String> exceptionWords = <String>[
   'try',
   'client',
   'hashCode',
-  'value',
   'override',
 ];
+
+List<String> exceptionWordsInEnum = <String>[...exceptionWords, 'value'];


### PR DESCRIPTION
In the upgrade to 3.0.1, I found that the `value` field in the model was changed to `$value`. However, `value` is not a reserved word in Dart.

```dart
@JsonSerializable(explicitToJson: true)
class StatisticalLabel {
  const EnrollStatisticsLabel({
    required this.describe,
    required this.$value,
    this.unit,
  });

  @JsonKey(name: 'describe')
  final String describe;
  @JsonKey(name: 'value')
  final String $value;
  @JsonKey(name: 'unit')
  final String? unit;
....
```

Upon checking the code, I discovered that #716 added `value` to `exceptionWords` to resolve conflicts with the `value` parameter in enums.

--------

I added `exceptionWordsInEnum` to ensure that `value` is treated as an exception only within enums.