### PR TITLE
Fix string encoding issue in JSON _download function

### DIFF
--- a/lib/swagger_dart_code_generator.dart
+++ b/lib/swagger_dart_code_generator.dart
@@ -349,5 +349,5 @@ $overridenModels
 Future<String> _download(String url) async {
   var response = await http.get(Uri.parse(url));
 
-  return response.body;
+  return utf8.decode(response.bodyBytes);
 }


### PR DESCRIPTION
Previously, the _download function directly returned the response body as a string, which could lead to improper character encoding. This commit changes the function to decode the response body bytes using utf8.decode. This ensures the function correctly handles different character encodings and improves the robustness of the data handling.