### PR TITLE
Fix missing 'import_paths' for Scalars when 'separate_models' is enabled

### DIFF
--- a/lib/swagger_dart_code_generator.dart
+++ b/lib/swagger_dart_code_generator.dart
@@ -333,7 +333,7 @@ $dateToJson
 import 'package:json_annotation/json_annotation.dart';
 import 'package:collection/collection.dart';
 import 'dart:convert';
-
+${options.importPaths.map((e) => "import '$e';").join('\n')}
 $enumsImport
 $overridenModels
 


### PR DESCRIPTION
Fix an issue where 'import_paths' for Scalars were not included in the generated *.models.swagger.dart files when the 'separate_models' configuration option was enabled.