### PR TITLE
Fix generation of array of enums in OpenAPI 3

### DIFF
--- a/lib/src/code_generators/swagger_enums_generator.dart
+++ b/lib/src/code_generators/swagger_enums_generator.dart
@@ -133,7 +133,8 @@ ${allEnums.map((e) => e.toString()).join('\n')}
     definedParameters.addAll(swaggerRoot.components?.parameters ?? {});
 
     definedParameters.forEach((key, swaggerRequestParameter) {
-      final enumValues = swaggerRequestParameter.schema?.enumValues ??
+      final enumValues = swaggerRequestParameter.schema?.items?.enumValues ??
+          swaggerRequestParameter.schema?.enumValues ??
           swaggerRequestParameter.items?.enumValues ??
           swaggerRequestParameter.enumValues;
 
@@ -197,7 +198,8 @@ ${allEnums.map((e) => e.toString()).join('\n')}
           if (swaggerRequestParameter.enumValues.isNotEmpty) {
             enumValues = swaggerRequestParameter.enumValues;
           } else {
-            enumValues = swaggerRequestParameter.schema?.enumValues ??
+            enumValues = swaggerRequestParameter.schema?.items?.enumValues ??
+                swaggerRequestParameter.schema?.enumValues ??
                 swaggerRequestParameter.items?.enumValues ??
                 [];
           }

--- a/lib/src/code_generators/swagger_generator_base.dart
+++ b/lib/src/code_generators/swagger_generator_base.dart
@@ -134,6 +134,7 @@ abstract class SwaggerGeneratorBase {
           }
 
           final enumValues =
+              swaggerRequestParameter.schema?.items?.enumValues ??
               swaggerRequestParameter.schema?.enumValues ??
               swaggerRequestParameter.items?.enumValues ??
               [];

--- a/lib/src/code_generators/swagger_requests_generator.dart
+++ b/lib/src/code_generators/swagger_requests_generator.dart
@@ -600,6 +600,7 @@ class SwaggerRequestsGenerator extends SwaggerGeneratorBase {
     final format = parameter.format ?? parameter.schema?.format ?? '';
 
     if (parameter.items?.enumValues.isNotEmpty == true ||
+        parameter.schema?.items?.enumValues.isNotEmpty == true ||
         parameter.schema?.enumValues.isNotEmpty == true ||
         parameter.enumValues.isNotEmpty) {
       if (definedParameters.containsValue(parameter)) {


### PR DESCRIPTION
We already check for an array of enums in `items.enumValues`, however, this only applies to OpenAPI 2. With this change, we now introduce the same check for OpenAPI 3 as well.